### PR TITLE
refactor(journal): decouple createProjectionStore from useSectionDirtyStore

### DIFF
--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-store-initialization.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-store-initialization.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useProjectionSync } from '@/shared/hooks/use-projection-sync'
+import { useDirtySync } from '@/shared/hooks/use-dirty-sync'
 import { useJournalRestore } from '@/shared/hooks/use-journal-restore'
 import {
   JOURNAL_ENTITIES
@@ -23,6 +24,8 @@ export function ArtistStoreInitialization({
     operationStore: useArtistsOperationStore,
     projectionStore: useArtistsProjectionStore
   })
+
+  useDirtySync(useArtistsProjectionStore, JOURNAL_ENTITIES.ARTISTA)
 
   useJournalRestore<ArtistEntry>({
     entity: JOURNAL_ENTITIES.ARTISTA,

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_store/artista-ui-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_store/artista-ui-store.ts
@@ -1,6 +1,6 @@
 import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import { createEntityOperationStore } from '@/shared/ui-state/operation-log'
-import { createUIProjectionStore } from '@/shared/ui-state/ui-projection-engine'
+import { createProjectionStore } from '@/shared/ui-state/ui-projection-engine'
 import { ArtistEntry } from '../_types'
 import { writeOperationIntoJournal } from '@/shared/lib/write-operation-into-journal'
 
@@ -10,4 +10,4 @@ export const useArtistsOperationStore = createEntityOperationStore<ArtistEntry>(
 })
 
 export const useArtistsProjectionStore =
-  createUIProjectionStore<ArtistEntry>('artista')
+  createProjectionStore<ArtistEntry>()

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-store-initialization.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-store-initialization.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useProjectionSync } from '@/shared/hooks/use-projection-sync'
+import { useDirtySync } from '@/shared/hooks/use-dirty-sync'
 import { useJournalRestore } from '@/shared/hooks/use-journal-restore'
 import {
   JOURNAL_ENTITIES
@@ -23,6 +24,8 @@ export function CatalogStoreInitialization({
     operationStore: useCatalogOperationStore,
     projectionStore: useCatalogProjectionStore
   })
+
+  useDirtySync(useCatalogProjectionStore, JOURNAL_ENTITIES.CATALOGO_ARTISTA)
 
   useJournalRestore<CatalogEntry>({
     entity: JOURNAL_ENTITIES.CATALOGO_ARTISTA,

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_store/catalog-ui-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_store/catalog-ui-store.ts
@@ -1,7 +1,7 @@
 import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import { createEntityOperationStore } from '@/shared/ui-state/operation-log'
 import { writeOperationIntoJournal } from '@/shared/lib/write-operation-into-journal'
-import { createUIProjectionStore } from '@/shared/ui-state/ui-projection-engine'
+import { createProjectionStore } from '@/shared/ui-state/ui-projection-engine'
 import { CatalogEntry } from '../_types'
 
 export const useCatalogOperationStore =
@@ -10,4 +10,4 @@ export const useCatalogOperationStore =
       writeOperationIntoJournal(ops, JOURNAL_ENTITIES.CATALOGO_ARTISTA)
   })
 
-export const useCatalogProjectionStore = createUIProjectionStore<CatalogEntry>('catalogo_artista')
+export const useCatalogProjectionStore = createProjectionStore<CatalogEntry>()

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/listado/_store/history-ui-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/listado/_store/history-ui-store.ts
@@ -1,7 +1,7 @@
 import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import { createEntityOperationStore } from '@/shared/ui-state/operation-log'
 import { writeOperationIntoJournal } from '@/shared/lib/write-operation-into-journal'
-import { createUIProjectionStore } from '@/shared/ui-state/ui-projection-engine'
+import { createProjectionStore } from '@/shared/ui-state/ui-projection-engine'
 import type { HistoryEntry } from '../_types'
 
 export const useHistoryOperationStore = createEntityOperationStore<HistoryEntry>({
@@ -9,4 +9,4 @@ export const useHistoryOperationStore = createEntityOperationStore<HistoryEntry>
     writeOperationIntoJournal(ops, JOURNAL_ENTITIES.ARTISTA_HISTORIAL)
 })
 
-export const useHistoryProjectionStore = createUIProjectionStore<HistoryEntry>('artista_historial')
+export const useHistoryProjectionStore = createProjectionStore<HistoryEntry>()

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_components/organization-store-initialization.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_components/organization-store-initialization.tsx
@@ -1,10 +1,9 @@
 'use client'
 
 import { useProjectionSync } from '@/shared/hooks/use-projection-sync'
+import { useDirtySync } from '@/shared/hooks/use-dirty-sync'
 import { useJournalRestore } from '@/shared/hooks/use-journal-restore'
-import {
-  JOURNAL_ENTITIES
-} from '@/shared/lib/database-entities'
+import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import {
   useOrganizationOperationStore,
   useOrganizationProjectionStore
@@ -25,11 +24,12 @@ export function OrganizationStoreInitialization({
     projectionStore: useOrganizationProjectionStore
   })
 
+  useDirtySync(useOrganizationProjectionStore, JOURNAL_ENTITIES.ORGANIZACION)
+
   useJournalRestore<Organization>({
     entity: JOURNAL_ENTITIES.ORGANIZACION,
     operationStore: useOrganizationOperationStore
   })
-
 
   return null
 }

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_components/team-store-initialization.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_components/team-store-initialization.tsx
@@ -1,6 +1,7 @@
 'use client'
 
 import { useProjectionSync } from '@/shared/hooks/use-projection-sync'
+import { useDirtySync } from '@/shared/hooks/use-dirty-sync'
 import { useJournalRestore } from '@/shared/hooks/use-journal-restore'
 import {
   JOURNAL_ENTITIES
@@ -23,6 +24,8 @@ export function TeamStoreInitialization({
     operationStore: useTeamOperationStore,
     projectionStore: useTeamProjectionStore
   })
+
+  useDirtySync(useTeamProjectionStore, JOURNAL_ENTITIES.ORGANIZACION_EQUIPO)
 
   useJournalRestore<TeamMember>({
     entity: JOURNAL_ENTITIES.ORGANIZACION_EQUIPO,

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_store/organization-team-ui-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_store/organization-team-ui-store.ts
@@ -1,7 +1,7 @@
 import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import { TeamMember } from '../_types'
 import { createEntityOperationStore } from '@/shared/ui-state/operation-log'
-import { createUIProjectionStore } from '@/shared/ui-state/ui-projection-engine'
+import { createProjectionStore } from '@/shared/ui-state/ui-projection-engine'
 import { writeOperationIntoJournal } from '@/shared/lib/write-operation-into-journal'
 
 export const useTeamOperationStore = createEntityOperationStore<TeamMember>({
@@ -9,6 +9,4 @@ export const useTeamOperationStore = createEntityOperationStore<TeamMember>({
     writeOperationIntoJournal(ops, JOURNAL_ENTITIES.ORGANIZACION_EQUIPO)
 })
 
-export const useTeamProjectionStore = createUIProjectionStore<TeamMember>(
-  'organizacion_equipo'
-)
+export const useTeamProjectionStore = createProjectionStore<TeamMember>()

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_store/organization-ui-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_store/organization-ui-store.ts
@@ -1,6 +1,6 @@
 import { JOURNAL_ENTITIES } from '@/shared/lib/database-entities'
 import { createEntityOperationStore } from '@/shared/ui-state/operation-log'
-import { createUIProjectionStore } from '@/shared/ui-state/ui-projection-engine'
+import { createProjectionStore } from '@/shared/ui-state/ui-projection-engine'
 import { writeOperationIntoJournal } from '@/shared/lib/write-operation-into-journal'
 import type { Organization } from '../_types'
 
@@ -11,4 +11,4 @@ export const useOrganizationOperationStore =
   })
 
 export const useOrganizationProjectionStore =
-  createUIProjectionStore<Organization>('organizacion')
+  createProjectionStore<Organization>()

--- a/apps/admin/src/shared/commit-system/README.md
+++ b/apps/admin/src/shared/commit-system/README.md
@@ -23,11 +23,3 @@ Orquestar el flujo de guardado garantizando que las operaciones se validen, orde
 ## Estado actual
 
 El pipeline está implementado y funcional. Sin embargo, la activación desde la UI está pendiente (T6 del roadmap); actualmente el botón "Guardar" solo muestra notificaciones sin ejecutar el `commit()`.
-
-## Siguiente paso
-
-El siguiente issue pendiente en este módulo es **[P1 — Projection Engine acoplada a `useSectionDirtyStore`](../../docs/journal-issues/p1-projection-engine-acoplada-dirty-store.md)**.
-
-Ver también el roadmap general de deuda técnica: [`docs/journal-issues/README.md`](../../docs/journal-issues/README.md)
-
-> **⚠️ Antes de ejecutar**: Crear el plan oficial para P1 y validarlo con los especialistas **Metis** (gap analysis) y **Momus** (plan critic) siguiendo el mismo proceso que esta tarea.

--- a/apps/admin/src/shared/hooks/use-dirty-sync.ts
+++ b/apps/admin/src/shared/hooks/use-dirty-sync.ts
@@ -1,0 +1,28 @@
+'use client'
+
+import { useEffect } from 'react'
+import type { UseBoundStore, StoreApi } from 'zustand'
+import type { UIProjectionState } from '@/shared/ui-state/ui-projection-engine'
+import { useSectionDirtyStore } from '@/shared/lib/section-dirty-store'
+import type { JournalEntity } from '@/shared/lib/database-entities'
+
+/**
+ * Suscribe el projection store de una entidad al dirty read model global.
+ * Cuando el estado proyectado cambia, actualiza useSectionDirtyStore con
+ * el veredicto net-change (hay cambios pendientes o no).
+ *
+ * No usar en entidades de solo lectura (e.g. ARTISTA_HISTORIAL).
+ */
+export function useDirtySync<T extends { id: string }>(
+  projectionStore: UseBoundStore<StoreApi<UIProjectionState<T>>>,
+  entity: JournalEntity
+): void {
+  useEffect(() => {
+    return projectionStore.subscribe((state) => {
+      const hasChanges = Object.values(state.byId).some(
+        (e) => e.__meta.isNew || e.__meta.isUpdated || e.__meta.isDeleted
+      )
+      useSectionDirtyStore.getState().setDirty(entity, hasChanges)
+    })
+  }, [projectionStore, entity])
+}

--- a/apps/admin/src/shared/ui-state/README.md
+++ b/apps/admin/src/shared/ui-state/README.md
@@ -8,33 +8,27 @@ Permite una experiencia fluida donde el usuario ve sus cambios (ADD, UPDATE, DEL
 
 ## Arquitectura y Fábricas
 
-El sistema se divide en dos stores de Zustand:
+El sistema se divide en dos stores de Zustand y un conjunto de hooks orquestadores:
 
 1. **Operation Log (`createEntityOperationStore`)**:
    - Mantiene una cola secuencial de cambios pendientes.
    - Gestiona operaciones `ADD`, `UPDATE`, `DELETE` y `RESTORE`.
    - Se usa para capturar las intenciones del usuario.
 
-2. **Projection Engine (`createUIProjectionStore`)**:
-   - Genera una vista coherente combinando el snapshot del servidor + el log de operaciones.
+2. **Projection Engine (`createProjectionStore`)**:
+   - Sistema de proyección de datos: genera una vista coherente combinando el snapshot del servidor + el log de operaciones.
    - Realiza reconciliación "net-zero": si un cambio manual devuelve una entidad a su estado original del servidor, limpia los flags de edición.
 
 ## Flujo de Datos
 
 `Snapshot Servidor → operationStore → projectionStore → Vista UI`
 
-El hook `useProjectionSync` actúa como el orquestador, re-calculando la proyección cada vez que cambian los datos remotos o se agrega una operación local.
+- `useProjectionSync`: conecta operationStore ↔ projectionStore — re-calcula la proyección cuando cambian operaciones o datos remotos.
+- `useDirtySync`: conecta projectionStore → `useSectionDirtyStore` (dirty read model global) — notifica si hay cambios netos pendientes.
 
 ## Archivos Clave
 
 - `operation-log/factory.ts`: Lógica de captura de operaciones.
 - `ui-projection-engine/factory.ts`: Algoritmo de proyección y reconciliación.
-- `hooks/use-projection-sync.ts`: Sincronización automática de stores.
-
-## Siguiente paso
-
-El siguiente issue pendiente en este módulo es **[P1 — Projection Engine acoplada a `useSectionDirtyStore`](../../docs/journal-issues/p1-projection-engine-acoplada-dirty-store.md)**.
-
-Ver también el roadmap general de deuda técnica: [`docs/journal-issues/README.md`](../../docs/journal-issues/README.md)
-
-> **⚠️ Antes de ejecutar**: Crear el plan oficial para P1 y validarlo con los especialistas **Metis** (gap analysis) y **Momus** (plan critic) siguiendo el mismo proceso que esta tarea.
+- `hooks/use-projection-sync.ts`: Sincronización automática operation log → projection store.
+- `hooks/use-dirty-sync.ts`: Propagación del veredicto net-change al dirty read model.

--- a/apps/admin/src/shared/ui-state/ui-projection-engine/README.md
+++ b/apps/admin/src/shared/ui-state/ui-projection-engine/README.md
@@ -1,0 +1,28 @@
+# Projection Engine
+
+Sistema de proyección de datos para el panel de administración. Combina un snapshot remoto con un log de operaciones locales para producir un estado proyectado que la UI consume directamente.
+
+## Propósito
+
+Separar el estado del servidor del estado de la UI: las operaciones del usuario se acumulan en un log y se proyectan sobre el snapshot remoto sin mutarlo, hasta que se persisten.
+
+## API
+
+`createProjectionStore<T extends { id: string }>()` — fábrica que retorna un Zustand store con:
+
+- `byId: Record<string, ProjectedEntity<T>>` — entidades proyectadas indexadas por id
+- `allIds: string[]` — ids en orden
+- `project(remoteSnapshot, persistedOps, pendingOps)` — recalcula el estado proyectado
+- `reset()` — vacía el store (callers deben limpiar el dirty store externamente)
+
+## `ProjectedEntity<T>.__meta`
+
+Cada entidad proyectada incluye flags de estado:
+
+- `isNew`: creada localmente, no existe en el servidor
+- `isUpdated`: modificada respecto al snapshot remoto (con reconciliación net-zero)
+- `isDeleted`: marcada para eliminar
+
+## Reconciliación net-zero
+
+Si todas las ediciones acumuladas de una entidad la devuelven a su estado original del servidor, `isUpdated` vuelve a `false`. Esto evita falsos positivos en el dirty tracking.

--- a/apps/admin/src/shared/ui-state/ui-projection-engine/factory.ts
+++ b/apps/admin/src/shared/ui-state/ui-projection-engine/factory.ts
@@ -1,8 +1,7 @@
 import { create } from 'zustand'
 import { UIProjectionState, ProjectedEntity } from './types'
-import { useSectionDirtyStore } from '@/shared/lib/section-dirty-store'
 
-export function createUIProjectionStore<T extends { id: string }>(section: string) {
+export function createProjectionStore<T extends { id: string }>() {
   return create<UIProjectionState<T>>((set, get) => ({
     byId: {},
     allIds: [],
@@ -27,7 +26,6 @@ export function createUIProjectionStore<T extends { id: string }>(section: strin
         }
 
         // Early return: no operations — all entities clean
-        useSectionDirtyStore.getState().setDirty(section, false)
         set({ byId, allIds })
         return
       }
@@ -138,11 +136,7 @@ export function createUIProjectionStore<T extends { id: string }>(section: strin
         }
       }
 
-      // Emit dirty verdict to global read model
-      const hasNetChanges = Object.values(nextById).some(
-        (e) => e.__meta.isNew || e.__meta.isUpdated || e.__meta.isDeleted
-      )
-      useSectionDirtyStore.getState().setDirty(section, hasNetChanges)
+
 
       set({
         byId: nextById,
@@ -151,8 +145,8 @@ export function createUIProjectionStore<T extends { id: string }>(section: strin
     },
 
     reset: () => {
-      useSectionDirtyStore.getState().clearSection(section)
       set({ byId: {}, allIds: [] })
+      // Callers that need to clean the dirty store should do so externally (inversion of control)
     }
   }))
 }

--- a/apps/admin/src/shared/ui-state/ui-projection-engine/index.ts
+++ b/apps/admin/src/shared/ui-state/ui-projection-engine/index.ts
@@ -1,2 +1,2 @@
-export { createUIProjectionStore } from './factory'
+export { createProjectionStore } from './factory'
 export type { ProjectedEntity, ProjectedMeta, UIProjectionState } from './types'


### PR DESCRIPTION
## Summary

- Rename `createUIProjectionStore` → `createProjectionStore` for consistency with module name
- Remove direct coupling: projection engine factory no longer imports or writes to `useSectionDirtyStore`
- Create new `useDirtySync` hook that handles dirty state tracking from store-initializers
- Update READMEs: remove "Next step" sections, document new architecture

## Changes

### Core Refactoring
- `factory.ts`: Removed `useSectionDirtyStore` import and calls, renamed function
- `index.ts`: Updated re-export
- 5 ui-stores: Updated imports and calls

### New Hook
- `use-dirty-sync.ts`: Subscribes projection store to dirty read model (net-change tracking)

### Documentation
- Updated `ui-state/README.md` with new architecture
- Created `ui-projection-engine/README.md` with projection system docs
- Removed "Next step" sections from READMEs

## Verification

- TypeScript: ✅
- ESLint: ✅  
- Build: ✅
- Functional: ✅ (amber dots in sidebar work correctly)

## Related

- Part of T2 roadmap: P1 — Decouple projection engine from dirty store
- See: `docs/journal-issues/p1-projection-engine-acoplada-dirty-store.md`