### PR TITLE
refactor(journal): replace journal-changed event bus with Zustand subscriptions

### DIFF
--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_hooks/use-artista-commit.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_hooks/use-artista-commit.ts
@@ -21,7 +21,6 @@ export function useArtistaCommit() {
       store.resetStore()
       router.refresh()
       toast.success('Guardado correctamente')
-      window.dispatchEvent(new CustomEvent('journal-changed'))
     }
   })
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_hooks/use-catalogo-commit.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_hooks/use-catalogo-commit.ts
@@ -21,7 +21,6 @@ export function useCatalogoCommit() {
       store.resetStore()
       router.refresh()
       toast.success('Guardado correctamente')
-      window.dispatchEvent(new CustomEvent('journal-changed'))
     }
   })
 

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_hooks/use-organizacion-commit.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_hooks/use-organizacion-commit.ts
@@ -24,7 +24,6 @@ export function useOrganizacionCommit() {
       orgStore.resetStore()
       router.refresh()
       toast.success('Guardado correctamente')
-      window.dispatchEvent(new CustomEvent('journal-changed'))
     }
   })
 
@@ -56,7 +55,6 @@ export function useOrganizacionEquipoCommit() {
       teamStore.resetStore()
       router.refresh()
       toast.success('Guardado correctamente')
-      window.dispatchEvent(new CustomEvent('journal-changed'))
     }
   })
 

--- a/apps/admin/src/shared/hooks/README.md
+++ b/apps/admin/src/shared/hooks/README.md
@@ -1,0 +1,31 @@
+# Shared Hooks
+
+Hooks de React compartidos entre módulos del panel de administración. Todos son hooks de efecto puro — no renderizan nada, solo sincronizan estado.
+
+## Hooks
+
+| Hook                | Propósito                                                                                                                                                    |
+| ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `useJournalRestore` | Hidrata el operation store desde IndexedDB al montar. Detecta entradas persistidas y carga las operaciones en memoria.                                       |
+| `useDirtySync`      | **Productor del dirty read model.** Suscribe un projection store a `useSectionDirtyStore` — cuando `byId` tiene net changes, emite `setDirty(entity, true)`. |
+| `useProjectionSync` | Suscribe el operation store al projection store — cuando `persistedOperations` o `pendingOperations` cambia, llama `project()`.                              |
+| `useRouteChanges`   | Agrega dirty state de múltiples entidades a nivel de ruta. Lee `useSectionDirtyStore` y expone `isDirty`, `discardAll`.                                      |
+| `useFractionalDnd`  | Utilitario para drag-and-drop con índices fraccionales.                                                                                                      |
+
+## `useJournalRestore` — detalles
+
+Usa **suscripción Zustand vanilla** sobre `persistedOperations` del `operationStore` para detectar cambios:
+
+```typescript
+operationStore.subscribe((state, prevState) => {
+  if (state.persistedOperations !== prevState.persistedOperations) {
+    checkAndHydrate()
+  }
+})
+```
+
+Reemplaza el patrón anterior de `window.addEventListener('journal-changed', ...)`.
+
+**Guard `isDiscarding`**: previene que la suscripción llame `checkAndHydrate()` mientras `discardAll()` está activo — `clearPersistedOperations()` dispara la suscripción síncronamente, pero IndexedDB aún no está limpio en ese punto.
+
+No usar en entidades de solo lectura (e.g. `ARTISTA_HISTORIAL`).

--- a/apps/admin/src/shared/hooks/use-journal-restore.tsx
+++ b/apps/admin/src/shared/hooks/use-journal-restore.tsx
@@ -30,8 +30,11 @@ export function useJournalRestore<T>({
   const [hasRestoredEntries, setHasRestoredEntries] = useState(false)
   const [noticeVisible, setNoticeVisible] = useState(false)
   const isHydrated = useRef(false)
+  const isDiscarding = useRef(false)
 
   const checkAndHydrate = useCallback(async () => {
+    if (isDiscarding.current) return
+
     const hasPending = await hasEntries(entity)
 
     if (hasPending && !isHydrated.current) {
@@ -52,22 +55,34 @@ export function useJournalRestore<T>({
   }, [entity, operationStore])
 
   useEffect(() => {
-    window.addEventListener('journal-changed', checkAndHydrate)
-    window.dispatchEvent(new CustomEvent('journal-changed'))
-    return () => window.removeEventListener('journal-changed', checkAndHydrate)
-  }, [checkAndHydrate])
+    // Initial check on mount
+    checkAndHydrate()
+
+    // Subscribe to operation store — fires when persistedOperations reference changes.
+    // This replaces the previous window.addEventListener('journal-changed', ...) pattern.
+    // NOTE: checkAndHydrate is async; isHydrated.current is set synchronously before the
+    // potential second subscription callback resolves. Safe against double-hydration.
+    return operationStore.subscribe((state, prevState) => {
+      if (state.persistedOperations !== prevState.persistedOperations) {
+        checkAndHydrate()
+      }
+    })
+  }, [operationStore, checkAndHydrate])
 
   const dismissNotice = useCallback(() => {
     setNoticeVisible(false)
   }, [])
 
   const discardAll = useCallback(async () => {
+    isDiscarding.current = true
     operationStore.getState().clearPersistedOperations()
     await clearSection(entity)
-    window.dispatchEvent(new CustomEvent('journal-changed'))
     setHasRestoredEntries(false)
     setNoticeVisible(false)
     isHydrated.current = false
+    isDiscarding.current = false
+    // No dispatch needed here — clearPersistedOperations() triggers the Zustand subscription,
+    // but isDiscarding guard prevents checkAndHydrate from running during cleanup.
   }, [entity, operationStore])
 
   return { hasRestoredEntries, noticeVisible, dismissNotice, discardAll }

--- a/apps/admin/src/shared/hooks/use-journal-restore.tsx
+++ b/apps/admin/src/shared/hooks/use-journal-restore.tsx
@@ -59,14 +59,27 @@ export function useJournalRestore<T>({
     checkAndHydrate()
 
     // Subscribe to operation store — fires when persistedOperations reference changes.
-    // This replaces the previous window.addEventListener('journal-changed', ...) pattern.
+    // This covers: commitPendingOperations() completing, hydratePersistedOperations(),
+    // and clearPersistedOperations() calls.
     // NOTE: checkAndHydrate is async; isHydrated.current is set synchronously before the
     // potential second subscription callback resolves. Safe against double-hydration.
-    return operationStore.subscribe((state, prevState) => {
+    const unsubscribe = operationStore.subscribe((state, prevState) => {
       if (state.persistedOperations !== prevState.persistedOperations) {
         checkAndHydrate()
       }
     })
+
+    // DOM event listener: REQUIRED for useRouteChanges.discardAll() to work.
+    // useRouteChanges operates at route level and calls journalCommitSource.clear()
+    // which only clears IndexedDB (not Zustand store). The event notifies us to re-check
+    // IndexedDB and clear our Zustand store.
+    // See T4: docs/journal-issues/p3-dualidad-journal-restore-route-changes.md
+    window.addEventListener('journal-changed', checkAndHydrate)
+
+    return () => {
+      unsubscribe()
+      window.removeEventListener('journal-changed', checkAndHydrate)
+    }
   }, [operationStore, checkAndHydrate])
 
   const dismissNotice = useCallback(() => {

--- a/apps/admin/src/shared/hooks/use-route-changes.ts
+++ b/apps/admin/src/shared/hooks/use-route-changes.ts
@@ -23,6 +23,12 @@ export function useRouteChanges(routePath: string) {
   const discardAll = useCallback(async () => {
     const currentEntities = ROUTE_ENTITY_MAP[routePath] ?? []
     await Promise.all(currentEntities.map((e) => journalCommitSource.clear(e)))
+    // NOTE: This dispatch is intentionally kept. useRouteChanges operates at route level
+    // and has no direct access to per-entity operation stores. The event notifies all
+    // useJournalRestore instances to re-check IndexedDB and clear their stale state.
+    // Removing this dispatch requires solving the route-level→store communication
+    // problem, which is part of T4's scope (dualidad useJournalRestore/useRouteChanges).
+    // See: docs/journal-issues/p3-dualidad-journal-restore-route-changes.md
     window.dispatchEvent(new CustomEvent('journal-changed'))
   }, [routePath])
 

--- a/apps/admin/src/shared/ui-state/operation-log/factory.ts
+++ b/apps/admin/src/shared/ui-state/operation-log/factory.ts
@@ -92,8 +92,6 @@ export function createEntityOperationStore<T>({
           }
         })
         
-        // Dispatch event so UI components (sidebar, toolbar) update immediately
-        window.dispatchEvent(new CustomEvent('journal-changed'))
       } catch (error) {
         // TODO: Improve error handling
         console.error('[EntityState] Failed to commit edits:', error)

--- a/apps/admin/src/shared/ui-state/operation-log/hooks/use-auto-commit.ts
+++ b/apps/admin/src/shared/ui-state/operation-log/hooks/use-auto-commit.ts
@@ -25,7 +25,6 @@ export function useAutoCommit<T>(
 
           try {
             operationStore.getState().commitPendingOperations()
-            window.dispatchEvent(new CustomEvent('journal-changed'))
           } finally {
             isCommittingRef.current = false
           }
@@ -40,7 +39,6 @@ export function useAutoCommit<T>(
       const finalState = operationStore.getState()
       if (finalState.pendingOperations?.length) {
         finalState.commitPendingOperations()
-        window.dispatchEvent(new CustomEvent('journal-changed'))
       }
     }
   }, [operationStore, debounceMs])


### PR DESCRIPTION
## Summary

Replaces the untyped `window.dispatchEvent(new CustomEvent('journal-changed'))` global event bus with direct Zustand subscriptions in the journal system. This is Part 2 of the technical debt cleanup roadmap (T3 of 6 tasks).

## Changes

### Core Changes

1. **`use-journal-restore.tsx`**: Added Zustand vanilla subscription (`operationStore.subscribe()`) to detect changes in `persistedOperations`. Added `isDiscarding` ref to prevent race conditions during discard operations.

2. **Removed dispatch calls from**:
   - `factory.ts` (commitPendingOperations)
   - `use-auto-commit.ts` (2 dispatches in debounce and cleanup)
   - `use-organizacion-commit.ts` (2 dispatches in onSuccess)
   - `use-artista-commit.ts` (1 dispatch)
   - `use-catalogo-commit.ts` (1 dispatch)

3. **Documentation**: Created `src/shared/hooks/README.md` documenting the hooks and their responsibilities.

### Architecture Decision

The discard flow (`useRouteChanges.discardAll()`) still relies on the DOM event as a bridge. This is a **known issue** documented for T4 (P3 duality resolution). The proper fix will be to make `useRouteChanges` call the operation store directly instead of relying on the event bus.

## Verification

- ✅ Type-check passes
- ✅ Lint passes
- ✅ Playwright E2E tests pass:
  - Scenario A: Edit field → amber dot appears in sidebar + toolbar visible
  - Scenario B: Click Discard → amber dot disappears + toolbar hidden

## Commits

- `cd2bf27` refactor(journal): replace journal-changed event bus with Zustand subscriptions
- `7c5c4c0` refactor(journal): remove DOM event listener from useJournalRestore + document remaining dispatch
- `6b667f4` docs(journal): add shared/hooks README post-T3 refactor
- `e8636de` fix(journal): re-add DOM event listener - required for discard flow

## Next Steps

T4 will address the remaining `journal-changed` dispatch in `use-route-changes.ts` and resolve the duality between `useJournalRestore` and `useRouteChanges`.