### PR TITLE
feat(artistas): implement soft delete for artista, artista_imagen, and catalogo_artista

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,7 @@ packages/database/data/*.sql
 .turbo
 .sisyphus
 db-workspace/
+
+# OpenCode
+.agents/
+skills-lock.json

--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,4 @@ packages/database/data/*.sql
 # Turborepo
 .turbo
 .sisyphus
+db-workspace/

--- a/apps/admin/AGENTS.md
+++ b/apps/admin/AGENTS.md
@@ -19,9 +19,8 @@ src/
 │   ├── (authenticated)/                # Protected: sidebar layout
 │   │   ├── (dashboard)/dashboard/      # Overview page
 │   │   └── (admin)/                    # Admin features
-│   │       ├── artistas/               # Artist management (largest feature)
+│   │       ├── artistas/               # Artist management and base route (largest feature)
 │   │       │   ├── catalogo/           # Catalog sub-feature (25 files)
-│   │       │   └── listado/            # List sub-feature (16 files)
 │   │       ├── general/                # Organization + team management
 │   │       ├── eventos/                # Events (stub)
 │   │       └── config/                 # Configuration (stub)
@@ -140,6 +139,7 @@ Key hooks in `src/shared/hooks/`:
 - **Shadcn/ui** components at `@/shared/components/ui/` (Base UI primitives, not Radix)
 - **Zustand 5** stores created via factories (`createEntityOperationStore`, `createProjectionStore`, `createPaginationStore`, `createFilterStore`)
 - **Zod 4** for validation (double validation: client in `usePush`, server in Server Actions)
+- **Drizzle-Zod** for schema derivation (see Schema Guide below)
 - **Server Actions** accept `PushOperation[]`, use `validateOperationData()`, return `PushResult`
 - **DAL pattern:** `'use cache'` + `cacheTag()` in feature `_lib/` files
 - **UI text in Spanish** (user-facing labels), **code/comments in English**
@@ -178,3 +178,61 @@ Key hooks in `src/shared/hooks/`:
 - `eventos` and `config` routes are stubs — follow artistas pattern when implementing
 - Entity definitions in `src/shared/lib/database-entities.ts` must be updated when adding new entities
 - `ROUTE_ENTITY_MAP` in same file connects routes to entities for dirty-state tracking
+
+## Schema Guide (Drizzle-Zod)
+
+All Zod schemas in the admin app should derive from Drizzle table definitions. This ensures a single source of truth.
+
+### Pattern
+
+```typescript
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { artist } from '@frijolmagico/database/schema'
+
+// Server INSERT - exact DB schema, number IDs
+export const artistaInsertSchema = createInsertSchema(artist, {
+  pseudonimo: (s) => s.min(1, { message: 'El pseudónimo es obligatorio' }),
+  slug: (s) => s.min(1, { message: 'El slug es obligatorio' })
+})
+
+// Server UPDATE - all fields optional
+export const artistaUpdateSchema = createUpdateSchema(artist)
+
+// Client form - string IDs, simplified fields
+export const artistaFormSchema = artistaInsertSchema
+  .pick({
+    nombre: true,
+    pseudonimo: true
+  })
+  .extend({
+    pseudonimo: z.string().min(1)
+  })
+
+// Export types
+export type ArtistaInsertInput = typeof artistaInsertSchema._type
+export type ArtistaFormInput = typeof artistaFormSchema._type
+```
+
+### Client vs Server Validation
+
+| Layer                     | IDs      | Example                                        |
+| ------------------------- | -------- | ---------------------------------------------- |
+| **Server** (InsertSchema) | `number` | `eventoId: z.coerce.number().int().positive()` |
+| **Client** (FormSchema)   | `string` | `eventoId: z.string().min(1)`                  |
+
+### Imports
+
+```typescript
+// Drizzle tables
+import { artist, event, organization } from '@frijolmagico/database/schema'
+
+// Drizzle-Zod
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+```
+
+### Key Points
+
+- Use `.pipe(z.coerce.number())` for FK fields in insert schemas (client sends strings)
+- Preserve Spanish error messages in refinements
+- Use `.pick()`, `.omit()`, `.extend()` for form schemas
+- Export backward-compat aliases if needed: `export const artistaSchema = artistaInsertSchema`

--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -31,6 +31,8 @@
     "clsx": "^2.1.1",
     "date-fns": "^4.1.0",
     "dexie": "^4.3.0",
+    "drizzle-orm": "^0.45.1",
+    "drizzle-zod": "^0.8.3",
     "fractional-indexing": "^3.2.0",
     "lucide-react": "^0.563.0",
     "next": "^16.1.6",

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
@@ -13,11 +13,19 @@ import type {
   IdMapping
 } from '@/shared/push/lib/types'
 import { PUSH_OPERATION_TYPE } from '@/shared/push/lib/types'
+import type {
+  ArtistaInsertInput,
+  ArtistaUpdateInput,
+  ArtistaImagenInsertInput,
+  ArtistaImagenUpdateInput,
+  ArtistaInput,
+  ArtistaImagenInput
+} from '../_schemas/artista.schema'
 import {
-  artistaSchema,
-  artistaImagenSchema,
-  type ArtistaInput,
-  type ArtistaImagenInput
+  artistaInsertSchema,
+  artistaUpdateSchema,
+  artistaImagenInsertSchema,
+  artistaImagenUpdateSchema
 } from '../_schemas/artista.schema'
 import { validateOperationData } from '@/shared/push/lib/validators'
 import { stripUndefined } from '@/shared/lib/utils'
@@ -26,7 +34,8 @@ import {
   logServerError
 } from '@/shared/push/lib/error-handler'
 
-const { artista, artistaImagen } = artist
+const artistTable = artist.artist
+const artistImageTable = artist.artistImage
 
 /**
  * Save artista section changes to database
@@ -77,24 +86,29 @@ export async function saveArtistaAction(
           continue
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
-            await tx.delete(artista).where(eq(artista.id, Number(op.entityId)))
+            await tx
+              .delete(artistTable)
+              .where(eq(artistTable.id, Number(op.entityId)))
           }
         } else {
+          const isUpdate = op.type === PUSH_OPERATION_TYPE.UPDATE
+          const schema = isUpdate ? artistaUpdateSchema : artistaInsertSchema
           const validated = validateOperationData(
             op.data,
-            artistaSchema,
-            op.type === PUSH_OPERATION_TYPE.UPDATE
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            schema as any,
+            isUpdate
           )
           if (!validated.valid || !validated.data) {
             throw new Error(
               validated.errors?.[0]?.message ?? 'Validation failed'
             )
           }
-          const input = validated.data
+          const input = validated.data as Record<string, unknown>
 
           if (isTempId(op.entityId)) {
             const [result] = await tx
-              .insert(artista)
+              .insert(artistTable)
               .values({
                 ...input,
                 id: undefined
@@ -104,9 +118,9 @@ export async function saveArtistaAction(
             mappings.push(createIdMapping(op.entityId, result.id, 'artista'))
           } else {
             await tx
-              .update(artista)
+              .update(artistTable)
               .set(stripUndefined(input))
-              .where(eq(artista.id, Number(op.entityId)))
+              .where(eq(artistTable.id, Number(op.entityId)))
           }
         }
       }
@@ -117,14 +131,19 @@ export async function saveArtistaAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(artistaImagen)
-              .where(eq(artistaImagen.id, Number(op.entityId)))
+              .delete(artistImageTable)
+              .where(eq(artistImageTable.id, Number(op.entityId)))
           }
         } else {
-          const validated = validateOperationData(
+          const isImagenUpdate = op.type === PUSH_OPERATION_TYPE.UPDATE
+          const imagenSchema = isImagenUpdate
+            ? artistaImagenUpdateSchema
+            : artistaImagenInsertSchema
+          const validated = validateOperationData<ArtistaImagenInput>(
             op.data,
-            artistaImagenSchema,
-            op.type === PUSH_OPERATION_TYPE.UPDATE
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            imagenSchema as any,
+            isImagenUpdate
           )
           if (!validated.valid || !validated.data) {
             throw new Error(
@@ -148,7 +167,7 @@ export async function saveArtistaAction(
 
           if (isTempId(op.entityId)) {
             const [result] = await tx
-              .insert(artistaImagen)
+              .insert(artistImageTable)
               .values({
                 ...input,
                 artistaId: resolvedArtistaId,
@@ -159,14 +178,14 @@ export async function saveArtistaAction(
             mappings.push(createIdMapping(op.entityId, result.id, 'artista'))
           } else {
             await tx
-              .update(artistaImagen)
+              .update(artistImageTable)
               .set(
                 stripUndefined({
                   ...input,
                   artistaId: resolvedArtistaId
                 })
               )
-              .where(eq(artistaImagen.id, Number(op.entityId)))
+              .where(eq(artistImageTable.id, Number(op.entityId)))
           }
         }
       }

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
@@ -4,7 +4,7 @@ import { updateTag } from 'next/cache'
 import { ARTISTA_CACHE_TAG } from '../_constants'
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { isNotDeleted } from '@frijolmagico/database/filters'
 import { requireAuth } from '@/lib/auth/utils'
 import { createIdMapping, isTempId } from '@/shared/push/lib/id-mapper'
@@ -89,7 +89,7 @@ export async function saveArtistaAction(
           if (!isTempId(op.entityId)) {
             await tx
               .update(artistTable)
-              .set({ deletedAt: new Date().toISOString() })
+              .set({ deletedAt: sql`CURRENT_TIMESTAMP` })
               .where(
                 and(
                   eq(artistTable.id, Number(op.entityId)),
@@ -139,7 +139,7 @@ export async function saveArtistaAction(
           if (!isTempId(op.entityId)) {
             await tx
               .update(artistImageTable)
-              .set({ deletedAt: new Date().toISOString() })
+              .set({ deletedAt: sql`CURRENT_TIMESTAMP` })
               .where(
                 and(
                   eq(artistImageTable.id, Number(op.entityId)),

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
@@ -4,7 +4,8 @@ import { updateTag } from 'next/cache'
 import { ARTISTA_CACHE_TAG } from '../_constants'
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
+import { isNotDeleted } from '@frijolmagico/database/filters'
 import { requireAuth } from '@/lib/auth/utils'
 import { createIdMapping, isTempId } from '@/shared/push/lib/id-mapper'
 import type {
@@ -87,8 +88,14 @@ export async function saveArtistaAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(artistTable)
-              .where(eq(artistTable.id, Number(op.entityId)))
+              .update(artistTable)
+              .set({ deletedAt: new Date().toISOString() })
+              .where(
+                and(
+                  eq(artistTable.id, Number(op.entityId)),
+                  isNotDeleted(artistTable.deletedAt)
+                )
+              )
           }
         } else {
           const isUpdate = op.type === PUSH_OPERATION_TYPE.UPDATE
@@ -131,8 +138,14 @@ export async function saveArtistaAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(artistImageTable)
-              .where(eq(artistImageTable.id, Number(op.entityId)))
+              .update(artistImageTable)
+              .set({ deletedAt: new Date().toISOString() })
+              .where(
+                and(
+                  eq(artistImageTable.id, Number(op.entityId)),
+                  isNotDeleted(artistImageTable.deletedAt)
+                )
+              )
           }
         } else {
           const isImagenUpdate = op.type === PUSH_OPERATION_TYPE.UPDATE

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-container.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-container.tsx
@@ -31,7 +31,7 @@ export function ArtistListContainer({
 
   const { save, isPending, result } = useArtistaPush()
 
-  const { isDirty, discardAll } = useRouteChanges('/artistas/listado')
+  const { isDirty, discardAll } = useRouteChanges('/artistas')
 
   const lastToastRef = useRef<number>(0)
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_hooks/use-artista-push.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_hooks/use-artista-push.ts
@@ -7,7 +7,10 @@ import { journalPushSource } from '@/shared/lib/journal-push-source'
 import { useJournalFlushRegistry } from '@/shared/lib/journal-flush-registry'
 import { saveArtistaAction } from '../_actions/save-artista.action'
 import { useArtistsOperationStore } from '../_store/artista-ui-store'
-import { artistaImagenSchema, artistaSchema } from '../_schemas/artista.schema'
+import {
+  artistaImagenInsertSchema,
+  artistaInsertSchema
+} from '../_schemas/artista.schema'
 import { ENTITIES } from '@/shared/lib/database-entities'
 
 export function useArtistaPush() {
@@ -19,8 +22,8 @@ export function useArtistaPush() {
     executor: saveArtistaAction,
     section: ENTITIES.ARTISTA,
     validators: {
-      artista: artistaSchema,
-      artistaImagen: artistaImagenSchema
+      artista: artistaInsertSchema,
+      artistaImagen: artistaImagenInsertSchema
     },
     onSuccess: () => {
       store.cleanup()

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-artists-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-artists-data.ts
@@ -9,7 +9,7 @@ import { asc, eq } from 'drizzle-orm'
 import type { ArtistEntry } from '../_types'
 import { ARTISTA_CACHE_TAG } from '../_constants'
 
-const { artista, artistaEstado } = artist
+const { artist: artistTable, artistStatus } = artist
 
 export async function getArtists(): Promise<ArtistEntry[] | null> {
   'use cache'
@@ -17,12 +17,12 @@ export async function getArtists(): Promise<ArtistEntry[] | null> {
 
   const results = await db
     .select({
-      artista: artista,
-      estadoSlug: artistaEstado.slug
+      artista: artistTable,
+      estadoSlug: artistStatus.slug
     })
-    .from(artista)
-    .leftJoin(artistaEstado, eq(artista.estadoId, artistaEstado.id))
-    .orderBy(asc(artista.pseudonimo))
+    .from(artistTable)
+    .leftJoin(artistStatus, eq(artistTable.estadoId, artistStatus.id))
+    .orderBy(asc(artistTable.pseudonimo))
 
   if (results === undefined || results.length === 0) return null
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-artists-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-artists-data.ts
@@ -4,6 +4,7 @@ import { cacheTag } from 'next/cache'
 
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
+import { isNotDeleted } from '@frijolmagico/database/filters'
 import { asc, eq } from 'drizzle-orm'
 
 import type { ArtistEntry } from '../_types'
@@ -22,6 +23,7 @@ export async function getArtists(): Promise<ArtistEntry[] | null> {
     })
     .from(artistTable)
     .leftJoin(artistStatus, eq(artistTable.estadoId, artistStatus.id))
+    .where(isNotDeleted(artistTable.deletedAt))
     .orderBy(asc(artistTable.pseudonimo))
 
   if (results === undefined || results.length === 0) return null

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-history-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_lib/get-history-data.ts
@@ -14,8 +14,8 @@ export async function getHistoryData(): Promise<HistoryEntry[]> {
 
   const results = await db
     .select()
-    .from(artist.artistaHistorial)
-    .orderBy(asc(artist.artistaHistorial.createdAt))
+    .from(artist.artistHistory)
+    .orderBy(asc(artist.artistHistory.createdAt))
 
   if (results === undefined || results.length === 0) return []
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
@@ -1,56 +1,81 @@
 import { z } from 'zod'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { artist as artistSchema } from '@frijolmagico/database/schema'
 
-/**
- * Schema Zod para la tabla artista
- * Mapea desde Drizzle schema (packages/database/src/db/schema/artist.ts)
- */
-export const artistaSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  estadoId: z
-    .number()
-    .int()
-    .positive({ error: 'estadoId debe ser un entero positivo' })
-    .default(1),
-  nombre: z.string().optional(),
-  pseudonimo: z.string().min(1, { error: 'El pseudónimo es obligatorio' }),
-  slug: z.string().min(1, { error: 'El slug es obligatorio' }),
-  rut: z.string().optional(),
-  correo: z.string().optional(),
-  rrss: z.preprocess((val) => {
-    if (val && typeof val === 'object') return JSON.stringify(val)
-    return val
-  }, z.string().optional()),
-  ciudad: z.string().optional(),
-  pais: z.string().optional()
+const artistTable = artistSchema.artist
+const artistImageTable = artistSchema.artistImage
+
+export const artistaInsertSchema = createInsertSchema(artistTable, {
+  pseudonimo: (s: z.ZodType) =>
+    (s as z.ZodString).min(1, { error: 'El pseudónimo es obligatorio' }),
+  slug: (s: z.ZodType) =>
+    (s as z.ZodString).min(1, { error: 'El slug es obligatorio' }),
+  estadoId: (s: z.ZodType) =>
+    (s as z.ZodOptional<z.ZodDefault<z.ZodNumber>>).default(1),
+  rrss: () =>
+    z.preprocess((val) => {
+      if (val && typeof val === 'object') return JSON.stringify(val)
+      return val
+    }, z.string().optional()) as z.ZodType<string | undefined>
 })
 
-/**
- * Schema Zod para la tabla artista_imagen
- * Mapea desde Drizzle schema (packages/database/src/db/schema/artist.ts)
- */
-export const artistaImagenSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  artistaId: z
-    .number()
-    .int()
-    .positive({ error: 'artistaId debe ser un entero positivo' }),
-  imagenUrl: z.string().min(1, { error: 'La URL de imagen es obligatoria' }),
-  tipo: z.enum(['avatar', 'galeria'], {
-    error: "El tipo debe ser 'avatar' o 'galeria'"
-  }),
-  orden: z
-    .number()
-    .int()
-    .positive({ error: 'orden debe ser un entero positivo' })
-    .default(1),
-  metadata: z.preprocess((val) => {
-    if (val && typeof val === 'object') return JSON.stringify(val)
-    return val
-  }, z.string().optional())
+export const artistaUpdateSchema = createUpdateSchema(artistTable, {
+  pseudonimo: (s: z.ZodType) =>
+    (s as z.ZodString).min(1, { error: 'El pseudónimo es obligatorio' }),
+  rrss: () =>
+    z.preprocess((val) => {
+      if (val && typeof val === 'object') return JSON.stringify(val)
+      return val
+    }, z.string().optional()) as z.ZodType<string | undefined>
 })
 
-/**
- * Tipos TypeScript inferidos desde schemas Zod
- */
-export type ArtistaInput = z.infer<typeof artistaSchema>
-export type ArtistaImagenInput = z.infer<typeof artistaImagenSchema>
+export const artistaImagenInsertSchema = createInsertSchema(artistImageTable, {
+  artistaId: () => z.coerce.number().int().positive(),
+  imagenUrl: (s: z.ZodType) =>
+    (s as z.ZodString).min(1, { error: 'La URL de imagen es obligatoria' }),
+  tipo: (s: z.ZodType) => s as z.ZodType<'avatar' | 'galeria'>
+})
+
+export const artistaImagenUpdateSchema = createUpdateSchema(artistImageTable)
+
+export type ArtistaInsertInput = z.infer<typeof artistaInsertSchema>
+export type ArtistaUpdateInput = z.infer<typeof artistaUpdateSchema>
+export type ArtistaImagenInsertInput = z.infer<typeof artistaImagenInsertSchema>
+export type ArtistaImagenUpdateInput = z.infer<typeof artistaImagenUpdateSchema>
+
+export type ArtistaInput = ArtistaInsertInput
+export type ArtistaImagenInput = ArtistaImagenInsertInput
+
+export const artistaFormSchema = artistaInsertSchema
+  .pick({
+    nombre: true,
+    pseudonimo: true,
+    slug: true,
+    rut: true,
+    correo: true,
+    rrss: true,
+    ciudad: true,
+    pais: true,
+    telefono: true
+  })
+  .extend({
+    pseudonimo: z.string().min(1, { message: 'El pseudónimo es obligatorio' }),
+    slug: z.string().min(1, { message: 'El slug es obligatorio' }),
+    estadoId: z.string().min(1)
+  })
+
+export const artistaImagenFormSchema = artistaImagenInsertSchema
+  .pick({
+    artistaId: true,
+    imagenUrl: true,
+    tipo: true,
+    orden: true,
+    metadata: true
+  })
+  .extend({
+    artistaId: z.string().min(1, { message: 'El artista es obligatorio' }),
+    imagenUrl: z.string().min(1, { message: 'La URL es obligatoria' })
+  })
+
+export type ArtistaFormInput = z.infer<typeof artistaFormSchema>
+export type ArtistaImagenFormInput = z.infer<typeof artistaImagenFormSchema>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_types/index.ts
@@ -1,6 +1,6 @@
-import type { Artista } from '@frijolmagico/database/orm'
+import type { Artist } from '@frijolmagico/database/orm'
 
-export type RawArtist = Artista
+export type RawArtist = Artist
 
 export type ArtistEntry = Omit<RawArtist, 'id' | 'rrss'> & {
   id: string
@@ -14,9 +14,9 @@ export interface ArtistListFilters {
   city: string | null
   statusId: number | null
 }
-import type { ArtistaHistorial } from '@frijolmagico/database/orm'
+import type { ArtistHistory } from '@frijolmagico/database/orm'
 
-export type RawHistoryEntry = ArtistaHistorial
+export type RawHistoryEntry = ArtistHistory
 
 export type HistoryEntry = Omit<
   RawHistoryEntry,

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
@@ -20,8 +20,8 @@ import {
 import { createIdMapping, isTempId } from '@/shared/push/lib/id-mapper'
 import { validateOperationData } from '@/shared/push/lib/validators'
 import {
-  catalogoArtistaSchema,
-  type CatalogoArtistaInput
+  catalogoArtistaInsertSchema,
+  type CatalogoArtistaInsertInput
 } from '../_schemas/catalogo.schema'
 import { stripUndefined } from '@/shared/lib/utils'
 
@@ -51,15 +51,15 @@ export async function saveCatalogoAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(artist.catalogoArtista)
+              .delete(artist.catalogArtist)
               .where(
-                eq(artist.catalogoArtista.id, Number.parseInt(op.entityId, 10))
+                eq(artist.catalogArtist.id, Number.parseInt(op.entityId, 10))
               )
           }
         } else {
           const validated = validateOperationData(
             op.data,
-            catalogoArtistaSchema,
+            catalogoArtistaInsertSchema,
             op.type === PUSH_OPERATION_TYPE.UPDATE
           )
           if (!validated.valid || !validated.data) {
@@ -71,9 +71,9 @@ export async function saveCatalogoAction(
 
           if (isTempId(op.entityId)) {
             const [inserted] = await tx
-              .insert(artist.catalogoArtista)
-              .values(input as CatalogoArtistaInput)
-              .returning({ id: artist.catalogoArtista.id })
+              .insert(artist.catalogArtist)
+              .values(input as CatalogoArtistaInsertInput)
+              .returning({ id: artist.catalogArtist.id })
 
             if (inserted) {
               mappings.push(
@@ -82,10 +82,10 @@ export async function saveCatalogoAction(
             }
           } else {
             await tx
-              .update(artist.catalogoArtista)
+              .update(artist.catalogArtist)
               .set(stripUndefined(input))
               .where(
-                eq(artist.catalogoArtista.id, Number.parseInt(op.entityId, 10))
+                eq(artist.catalogArtist.id, Number.parseInt(op.entityId, 10))
               )
           }
         }

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
@@ -3,9 +3,10 @@
 import { updateTag } from 'next/cache'
 import { CATALOG_CACHE_TAG } from '../_constants'
 import { ARTISTA_CACHE_TAG } from '../../_constants'
-import { eq } from 'drizzle-orm'
+import { and, eq } from 'drizzle-orm'
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
+import { isNotDeleted } from '@frijolmagico/database/filters'
 import { requireAuth } from '@/lib/auth/utils'
 import {
   PUSH_OPERATION_TYPE,
@@ -51,9 +52,13 @@ export async function saveCatalogoAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(artist.catalogArtist)
+              .update(artist.catalogArtist)
+              .set({ deletedAt: new Date().toISOString() })
               .where(
-                eq(artist.catalogArtist.id, Number.parseInt(op.entityId, 10))
+                and(
+                  eq(artist.catalogArtist.id, Number.parseInt(op.entityId, 10)),
+                  isNotDeleted(artist.catalogArtist.deletedAt)
+                )
               )
           }
         } else {

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_actions/save-catalogo.action.ts
@@ -3,7 +3,7 @@
 import { updateTag } from 'next/cache'
 import { CATALOG_CACHE_TAG } from '../_constants'
 import { ARTISTA_CACHE_TAG } from '../../_constants'
-import { and, eq } from 'drizzle-orm'
+import { and, eq, sql } from 'drizzle-orm'
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
 import { isNotDeleted } from '@frijolmagico/database/filters'
@@ -53,7 +53,7 @@ export async function saveCatalogoAction(
           if (!isTempId(op.entityId)) {
             await tx
               .update(artist.catalogArtist)
-              .set({ deletedAt: new Date().toISOString() })
+              .set({ deletedAt: sql`CURRENT_TIMESTAMP` })
               .where(
                 and(
                   eq(artist.catalogArtist.id, Number.parseInt(op.entityId, 10)),

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_hooks/use-catalogo-push.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_hooks/use-catalogo-push.ts
@@ -7,7 +7,7 @@ import { journalPushSource } from '@/shared/lib/journal-push-source'
 import { useJournalFlushRegistry } from '@/shared/lib/journal-flush-registry'
 import { saveCatalogoAction } from '../_actions/save-catalogo.action'
 import { useCatalogOperationStore } from '../_store/catalog-ui-store'
-import { catalogoArtistaSchema } from '../_schemas/catalogo.schema'
+import { catalogoArtistaInsertSchema } from '../_schemas/catalogo.schema'
 import { ENTITIES } from '@/shared/lib/database-entities'
 
 export function useCatalogoPush() {
@@ -19,7 +19,7 @@ export function useCatalogoPush() {
     executor: saveCatalogoAction,
     section: ENTITIES.CATALOGO_ARTISTA,
     validators: {
-      catalogo_artista: catalogoArtistaSchema
+      catalogo_artista: catalogoArtistaInsertSchema
     },
     onSuccess: () => {
       store.cleanup()

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_lib/get-catalog-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_lib/get-catalog-data.ts
@@ -8,7 +8,7 @@ import type { CatalogEntry } from '../_types'
 import { cacheTag } from 'next/cache'
 import { CATALOG_CACHE_TAG } from '../_constants'
 
-const { catalogoArtista, artistaImagen } = artist
+const { catalogArtist, artistImage } = artist
 
 export async function getCatalogData(): Promise<CatalogEntry[] | null> {
   'use cache'
@@ -16,25 +16,26 @@ export async function getCatalogData(): Promise<CatalogEntry[] | null> {
 
   const results = await db
     .select({
-      id: catalogoArtista.id,
-      artistaId: catalogoArtista.artistaId,
-      orden: catalogoArtista.orden,
-      destacado: catalogoArtista.destacado,
-      activo: catalogoArtista.activo,
-      descripcion: catalogoArtista.descripcion,
-      createdAt: catalogoArtista.createdAt,
-      updatedAt: catalogoArtista.updatedAt,
-      avatarPath: artistaImagen.imagenUrl
+      id: catalogArtist.id,
+      artistaId: catalogArtist.artistaId,
+      orden: catalogArtist.orden,
+      destacado: catalogArtist.destacado,
+      activo: catalogArtist.activo,
+      descripcion: catalogArtist.descripcion,
+      createdAt: catalogArtist.createdAt,
+      updatedAt: catalogArtist.updatedAt,
+      deletedAt: catalogArtist.deletedAt,
+      avatarPath: artistImage.imagenUrl
     })
-    .from(catalogoArtista)
+    .from(catalogArtist)
     .leftJoin(
-      artistaImagen,
+      artistImage,
       and(
-        eq(artistaImagen.artistaId, catalogoArtista.artistaId),
-        eq(artistaImagen.tipo, 'avatar')
+        eq(artistImage.artistaId, catalogArtist.artistaId),
+        eq(artistImage.tipo, 'avatar')
       )
     )
-    .orderBy(asc(catalogoArtista.orden))
+    .orderBy(asc(catalogArtist.orden))
 
   if (results === undefined) return null
 
@@ -46,6 +47,7 @@ export async function getCatalogData(): Promise<CatalogEntry[] | null> {
     descripcion: row.descripcion,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
+    deletedAt: row.deletedAt,
     id: String(row.id),
     avatarUrl: getAvatarUrl(row.avatarPath)
   }))

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_lib/get-catalog-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_lib/get-catalog-data.ts
@@ -2,6 +2,7 @@
 
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
+import { isNotDeleted } from '@frijolmagico/database/filters'
 import { eq, and, asc } from 'drizzle-orm'
 import { getAvatarUrl } from '@/lib/cdn'
 import type { CatalogEntry } from '../_types'
@@ -32,9 +33,11 @@ export async function getCatalogData(): Promise<CatalogEntry[] | null> {
       artistImage,
       and(
         eq(artistImage.artistaId, catalogArtist.artistaId),
-        eq(artistImage.tipo, 'avatar')
+        eq(artistImage.tipo, 'avatar'),
+        isNotDeleted(artistImage.deletedAt)
       )
     )
+    .where(isNotDeleted(catalogArtist.deletedAt))
     .orderBy(asc(catalogArtist.orden))
 
   if (results === undefined) return null

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.ts
@@ -1,28 +1,34 @@
 import { z } from 'zod'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { artist } from '@frijolmagico/database/schema'
 
-/**
- * Schema Zod para la tabla catalogo_artista
- * Mapea desde Drizzle schema (packages/database/src/db/schema/artist.ts)
- *
- * Nota: catalogoArtista está en artist.ts en Drizzle, pero conceptualmente
- * pertenece a la sección catalogo-entry.
- */
-export const catalogoArtistaSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  artistaId: z
-    .number()
-    .int()
-    .positive()
-    .min(1, { error: 'El artista es obligatorio' }),
-  orden: z.string().min(1, { error: 'El orden es obligatorio' }),
-  destacado: z
-    .boolean({ error: 'destacado debe ser un booleano' })
-    .default(false),
-  activo: z.boolean({ error: 'activo debe ser un booleano' }).default(true),
-  descripcion: z.string().optional()
-})
+export const catalogoArtistaInsertSchema = createInsertSchema(
+  artist.catalogArtist,
+  {
+    artistaId: (s) =>
+      s.int().positive().min(1, { error: 'El artista es obligatorio' }),
+    orden: (s) => s.min(1, { error: 'El orden es obligatorio' })
+  }
+)
 
-/**
- * Tipos TypeScript inferidos desde schema Zod
- */
-export type CatalogoArtistaInput = z.infer<typeof catalogoArtistaSchema>
+export const catalogoArtistaUpdateSchema = createUpdateSchema(
+  artist.catalogArtist
+)
+
+export type CatalogoArtistaInsertInput = z.infer<
+  typeof catalogoArtistaInsertSchema
+>
+
+export const catalogoArtistaFormSchema = catalogoArtistaInsertSchema
+  .pick({
+    artistaId: true,
+    orden: true,
+    descripcion: true
+  })
+  .extend({
+    artistaId: z.string().min(1, { message: 'El artista es obligatorio' }),
+    destacado: z.boolean().default(false),
+    activo: z.boolean().default(true)
+  })
+
+export type CatalogoArtistaFormInput = z.infer<typeof catalogoArtistaFormSchema>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_types/index.ts
@@ -1,7 +1,7 @@
-import type { CatalogoArtista } from '@frijolmagico/database/orm'
+import type { CatalogArtist as RawCatalogArtist } from '@frijolmagico/database/orm'
 import { ArtistEntry } from '../../_types'
 
-export type RawCatalogEntry = CatalogoArtista
+export type RawCatalogEntry = RawCatalogArtist
 
 export type CatalogEntry = Omit<RawCatalogEntry, 'id' | 'artistaId'> & {
   id: string

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/_actions/save-evento.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/_actions/save-evento.action.ts
@@ -17,13 +17,14 @@ import {
   handleServerActionError,
   logServerError
 } from '@/shared/push/lib/error-handler'
+import type { ZodSchema } from 'zod'
 import { createIdMapping, isTempId } from '@/shared/push/lib/id-mapper'
 import { validateOperationData } from '@/shared/push/lib/validators'
-import { eventoSchema, type EventoInput } from '../_schemas/evento.schema'
+import { eventoSchema, type EventoInsertInput } from '../_schemas/evento.schema'
 import { stripUndefined } from '@/shared/lib/utils'
 import { generateSlug } from '../_lib/slug-utils'
 
-const { evento } = events
+const { event: eventTable } = events
 
 /**
  * Save evento changes to database
@@ -52,13 +53,13 @@ export async function saveEventoAction(
         } else if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(evento)
-              .where(eq(evento.id, Number.parseInt(op.entityId, 10)))
+              .delete(eventTable)
+              .where(eq(eventTable.id, Number.parseInt(op.entityId, 10)))
           }
         } else {
-          const validated = validateOperationData(
+          const validated = validateOperationData<EventoInsertInput>(
             op.data,
-            eventoSchema,
+            eventoSchema as unknown as ZodSchema<EventoInsertInput>,
             op.type === PUSH_OPERATION_TYPE.UPDATE
           )
           if (!validated.valid || !validated.data) {
@@ -72,9 +73,9 @@ export async function saveEventoAction(
             // CREATE: Generate slug from nombre
             const slug = generateSlug(input.nombre as string)
             const [inserted] = await tx
-              .insert(evento)
-              .values({ ...input, slug } as EventoInput)
-              .returning({ id: evento.id })
+              .insert(eventTable)
+              .values({ ...input, slug })
+              .returning({ id: eventTable.id })
 
             if (inserted) {
               mappings.push(createIdMapping(op.entityId, inserted.id, 'evento'))
@@ -86,9 +87,9 @@ export async function saveEventoAction(
               updateData.slug = generateSlug(updateData.nombre as string)
             }
             await tx
-              .update(evento)
+              .update(eventTable)
               .set(updateData)
-              .where(eq(evento.id, Number.parseInt(op.entityId, 10)))
+              .where(eq(eventTable.id, Number.parseInt(op.entityId, 10)))
           }
         }
       }

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/_lib/get-eventos-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/_lib/get-eventos-data.ts
@@ -7,7 +7,7 @@ import { cacheTag } from 'next/cache'
 import type { EventoEntry } from '../_types'
 import { EVENTO_CACHE_TAG } from '../_constants'
 
-const { evento } = events
+const { event: eventTable } = events
 
 export async function getEventos(): Promise<EventoEntry[] | null> {
   'use cache'
@@ -15,9 +15,9 @@ export async function getEventos(): Promise<EventoEntry[] | null> {
 
   const results = await db
     .select()
-    .from(evento)
-    .where(eq(evento.organizacionId, 1))
-    .orderBy(asc(evento.nombre))
+    .from(eventTable)
+    .where(eq(eventTable.organizacionId, 1))
+    .orderBy(asc(eventTable.nombre))
 
   if (results === undefined) return null
 

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/_schemas/evento.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/_schemas/evento.schema.ts
@@ -1,32 +1,24 @@
 import { z } from 'zod'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { events } from '@frijolmagico/database/schema'
 
-/**
- * Schema Zod para la tabla evento (server validation)
- * Mapea desde Drizzle schema (packages/database/src/db/schema/events.ts)
- */
-export const eventoSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  organizacionId: z
-    .number()
-    .int()
-    .positive({ error: 'organizacionId debe ser un entero positivo' })
-    .default(1),
-  nombre: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  slug: z.string().min(1, { error: 'El slug es obligatorio' }),
-  descripcion: z.string().optional()
+const { event } = events
+
+export const eventoInsertSchema = createInsertSchema(event, {
+  nombre: (s) => s.min(1, { message: 'El nombre es obligatorio' }),
+  slug: (s) => s.min(1, { message: 'El slug es obligatorio' }),
+  organizacionId: (s) => s.default(1)
 })
 
-/**
- * Schema Zod para el formulario de evento (client validation)
- * Versión simplificada para UI forms
- */
-export const eventoFormSchema = z.object({
-  nombre: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  descripcion: z.string().optional()
+export const eventoUpdateSchema = createUpdateSchema(event)
+
+export const eventoSchema = eventoInsertSchema
+
+export const eventoFormSchema = eventoInsertSchema.pick({
+  nombre: true,
+  descripcion: true
 })
 
-/**
- * Tipos TypeScript inferidos desde schemas Zod
- */
-export type EventoInput = z.infer<typeof eventoSchema>
+export type EventoInsertInput = z.infer<typeof eventoInsertSchema>
 export type EventoFormInput = z.infer<typeof eventoFormSchema>
+export type EventoInput = EventoInsertInput

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/_types/index.ts
@@ -1,6 +1,6 @@
-import type { Evento } from '@frijolmagico/database/orm'
+import type { Event } from '@frijolmagico/database/orm'
 
-export type EventoEntry = Omit<Evento, 'id' | 'organizacionId'> & {
+export type EventoEntry = Omit<Event, 'id' | 'organizacionId'> & {
   id: string
   organizacionId: number
 }

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_actions/save-edicion.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_actions/save-edicion.action.ts
@@ -22,16 +22,16 @@ import {
   logServerError
 } from '@/shared/push/lib/error-handler'
 import {
-  edicionSchema,
-  edicionDiaSchema,
-  lugarSchema,
+  edicionInsertSchema,
+  edicionDiaInsertSchema,
+  lugarInsertSchema,
   type EdicionInput,
   type EdicionDiaInput,
   type LugarInput
 } from '../_schemas/edicion.schema'
 
 const { place } = core
-const { eventoEdicion, eventoEdicionDia } = events
+const { eventEdition, eventEditionDay } = events
 
 function resolveNumberFk(
   value: unknown,
@@ -103,7 +103,7 @@ export async function saveEdicionAction(
 
         const validated = validateOperationData(
           op.data,
-          lugarSchema,
+          lugarInsertSchema,
           op.type === PUSH_OPERATION_TYPE.UPDATE
         )
 
@@ -139,8 +139,8 @@ export async function saveEdicionAction(
         if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(eventoEdicion)
-              .where(eq(eventoEdicion.id, Number.parseInt(op.entityId, 10)))
+              .delete(eventEdition)
+              .where(eq(eventEdition.id, Number.parseInt(op.entityId, 10)))
           }
           continue
         }
@@ -157,7 +157,7 @@ export async function saveEdicionAction(
 
         const validated = validateOperationData(
           dataWithResolvedEventoId,
-          edicionSchema,
+          edicionInsertSchema,
           op.type === PUSH_OPERATION_TYPE.UPDATE
         )
 
@@ -170,9 +170,9 @@ export async function saveEdicionAction(
         if (isTempId(op.entityId)) {
           const slug = generateEdicionSlug(input.numeroEdicion)
           const [inserted] = await tx
-            .insert(eventoEdicion)
+            .insert(eventEdition)
             .values({ ...input, slug } as EdicionInput)
-            .returning({ id: eventoEdicion.id })
+            .returning({ id: eventEdition.id })
 
           if (inserted) {
             mappings.push(
@@ -188,9 +188,9 @@ export async function saveEdicionAction(
         }
 
         await tx
-          .update(eventoEdicion)
+          .update(eventEdition)
           .set(updateData)
-          .where(eq(eventoEdicion.id, Number.parseInt(op.entityId, 10)))
+          .where(eq(eventEdition.id, Number.parseInt(op.entityId, 10)))
       }
 
       for (const op of diaOps) {
@@ -201,8 +201,8 @@ export async function saveEdicionAction(
         if (op.type === PUSH_OPERATION_TYPE.DELETE) {
           if (!isTempId(op.entityId)) {
             await tx
-              .delete(eventoEdicionDia)
-              .where(eq(eventoEdicionDia.id, Number.parseInt(op.entityId, 10)))
+              .delete(eventEditionDay)
+              .where(eq(eventEditionDay.id, Number.parseInt(op.entityId, 10)))
           }
           continue
         }
@@ -231,7 +231,7 @@ export async function saveEdicionAction(
 
         const validated = validateOperationData(
           dataWithResolvedFks,
-          edicionDiaSchema,
+          edicionDiaInsertSchema,
           op.type === PUSH_OPERATION_TYPE.UPDATE
         )
 
@@ -250,9 +250,9 @@ export async function saveEdicionAction(
 
         if (isTempId(op.entityId)) {
           const [inserted] = await tx
-            .insert(eventoEdicionDia)
+            .insert(eventEditionDay)
             .values(diaInsertData)
-            .returning({ id: eventoEdicionDia.id })
+            .returning({ id: eventEditionDay.id })
 
           if (inserted) {
             mappings.push(
@@ -263,9 +263,9 @@ export async function saveEdicionAction(
         }
 
         await tx
-          .update(eventoEdicionDia)
+          .update(eventEditionDay)
           .set(stripUndefined(diaInsertData))
-          .where(eq(eventoEdicionDia.id, Number.parseInt(op.entityId, 10)))
+          .where(eq(eventEditionDay.id, Number.parseInt(op.entityId, 10)))
       }
     })
 

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_hooks/use-edicion-push.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_hooks/use-edicion-push.ts
@@ -10,9 +10,9 @@ import { useEdicionOperationStore } from '../_store/edicion-ui-store'
 import { useEdicionDiaOperationStore } from '../_store/edicion-dia-ui-store'
 import { useLugarOperationStore } from '../_store/lugar-ui-store'
 import {
-  edicionSchema,
-  edicionDiaSchema,
-  lugarSchema
+  edicionInsertSchema,
+  edicionDiaInsertSchema,
+  lugarInsertSchema
 } from '../_schemas/edicion.schema'
 import { ENTITIES } from '@/shared/lib/database-entities'
 
@@ -31,9 +31,9 @@ export function useEdicionPush() {
       ENTITIES.LUGAR
     ],
     validators: {
-      evento_edicion: edicionSchema,
-      evento_edicion_dia: edicionDiaSchema,
-      lugar: lugarSchema
+      evento_edicion: edicionInsertSchema,
+      evento_edicion_dia: edicionDiaInsertSchema,
+      lugar: lugarInsertSchema
     },
     onSuccess: () => {
       edicionStore.cleanup()

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_lib/get-ediciones-data.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_lib/get-ediciones-data.ts
@@ -9,7 +9,7 @@ import { asc } from 'drizzle-orm'
 import type { EdicionEntry, EdicionDiaEntry, LugarEntry } from '../_types'
 import { EVENTO_EDICION_CACHE_TAG, LUGAR_CACHE_TAG } from '../../_constants'
 
-const { eventoEdicion, eventoEdicionDia } = events
+const { eventEdition, eventEditionDay } = events
 const { place } = core
 
 export async function getEdiciones(): Promise<{
@@ -21,13 +21,13 @@ export async function getEdiciones(): Promise<{
 
   const edicionesResults = await db
     .select()
-    .from(eventoEdicion)
-    .orderBy(asc(eventoEdicion.createdAt))
+    .from(eventEdition)
+    .orderBy(asc(eventEdition.createdAt))
 
   const diasResults = await db
     .select()
-    .from(eventoEdicionDia)
-    .orderBy(asc(eventoEdicionDia.fecha))
+    .from(eventEditionDay)
+    .orderBy(asc(eventEditionDay.fecha))
 
   if (edicionesResults === undefined || diasResults === undefined) return null
 

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_schemas/edicion.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_schemas/edicion.schema.ts
@@ -1,121 +1,77 @@
 import { z } from 'zod'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { core, events } from '@frijolmagico/database/schema'
 
-/**
- * Schema Zod para la tabla evento_edicion (server validation)
- * Mapea desde Drizzle schema (packages/database/src/db/schema/events.ts)
- */
-export const edicionSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  eventoId: z.coerce
-    .number()
-    .int()
-    .positive({ error: 'eventoId debe ser un entero positivo' }),
-  nombre: z.string().optional(),
-  numeroEdicion: z
-    .string()
-    .min(1, { error: 'El número de edición es obligatorio' }),
-  slug: z.string().min(1, { error: 'El slug es obligatorio' }),
-  posterUrl: z.string().optional()
+const { eventEdition, eventEditionDay } = events
+const { place } = core
+
+export const edicionInsertSchema = createInsertSchema(eventEdition, {
+  eventoId: () => z.coerce.number().int().positive(),
+  numeroEdicion: (s) =>
+    s.min(1, { message: 'El número de edición es obligatorio' }),
+  slug: (s) => s.min(1, { message: 'El slug es obligatorio' })
 })
 
-/**
- * Schema Zod para el formulario de edición (client validation)
- * Versión simplificada para UI forms
- */
-export const edicionFormSchema = z.object({
-  eventoId: z.string().min(1, { error: 'El evento es obligatorio' }),
-  nombre: z.string().optional(),
-  numeroEdicion: z
-    .string()
-    .min(1, { error: 'El número de edición es obligatorio' }),
-  posterUrl: z.string().optional()
-})
+export const edicionUpdateSchema = createUpdateSchema(eventEdition)
 
-/**
- * Schema Zod para la tabla evento_edicion_dia (server validation)
- * Mapea desde Drizzle schema (packages/database/src/db/schema/events.ts)
- */
-export const edicionDiaSchema = z.object({
-  id: z.number().int().positive().optional(),
-  eventoEdicionId: z.union([
-    z
-      .number()
-      .int()
-      .positive({ error: 'eventoEdicionId debe ser un entero positivo' }),
-    z.string().min(1)
-  ]),
-  lugarId: z
-    .union([
-      z
-        .number()
-        .int()
-        .positive({ error: 'lugarId debe ser un entero positivo' }),
-      z.string().min(1)
-    ])
-    .optional(),
-  fecha: z.string({ error: 'La fecha es obligatoria' }),
-  horaInicio: z.string({ error: 'La hora de inicio es obligatoria' }),
-  horaFin: z.string({ error: 'La hora de fin es obligatoria' }),
-  modalidad: z.enum(['presencial', 'online', 'hibrido'], {
-    error: "La modalidad debe ser 'presencial', 'online' o 'hibrido'"
+export const edicionSchema = edicionInsertSchema
+
+export const edicionFormSchema = edicionInsertSchema
+  .pick({
+    eventoId: true,
+    nombre: true,
+    numeroEdicion: true,
+    posterUrl: true
   })
+  .extend({
+    eventoId: z.string().min(1, { error: 'El evento es obligatorio' })
+  })
+
+export const edicionDiaInsertSchema = createInsertSchema(eventEditionDay, {
+  eventoEdicionId: () => z.coerce.number().int().positive(),
+  lugarId: (s) => s.optional(),
+  fecha: (s) => s.min(1, { message: 'La fecha es obligatoria' }),
+  horaInicio: (s) => s.min(1, { message: 'La hora de inicio es obligatoria' }),
+  horaFin: (s) => s.min(1, { message: 'La hora de fin es obligatoria' })
 })
 
-/**
- * Schema Zod para el formulario de día de edición (client validation)
- * Versión simplificada para UI forms
- */
-export const edicionDiaFormSchema = z.object({
-  fecha: z.string({ error: 'La fecha es obligatoria' }),
-  horaInicio: z.string({ error: 'La hora de inicio es obligatoria' }),
-  horaFin: z.string({ error: 'La hora de fin es obligatoria' }),
-  modalidad: z.enum(['presencial', 'online', 'hibrido'], {
-    error: "La modalidad debe ser 'presencial', 'online' o 'hibrido'"
-  }),
-  lugarId: z
-    .number()
-    .int()
-    .positive({ error: 'lugarId debe ser un entero positivo' })
-    .optional()
-})
+export const edicionDiaUpdateSchema = createUpdateSchema(eventEditionDay)
 
-/**
- * Schema Zod para la tabla lugar (server validation)
- * Mapea desde Drizzle schema (packages/database/src/db/schema/core.ts)
- */
-export const lugarSchema = z.object({
-  id: z.number().int().positive().optional(), // Optional for inserts (auto-increment)
-  nombre: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  direccion: z.string().optional(),
-  ciudad: z.string().optional(),
-  coordenadas: z.string().optional(),
+export const edicionDiaSchema = edicionDiaInsertSchema
+
+export const edicionDiaFormSchema = edicionDiaInsertSchema
+  .omit({ eventoEdicionId: true })
+  .extend({
+    eventoEdicionId: z.string().min(1),
+    lugarId: z.string().optional()
+  })
+
+export const lugarInsertSchema = createInsertSchema(place, {
+  nombre: (s) => s.min(1, { message: 'El nombre es obligatorio' }),
   url: z.url({ message: 'La URL debe ser válida' }).optional()
 })
 
-/**
- * Schema Zod para el formulario de lugar (client validation)
- * Versión simplificada para UI forms
- */
-export const lugarFormSchema = z.object({
-  nombre: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  direccion: z.string().optional(),
-  ciudad: z.string().optional(),
-  coordenadas: z.string().optional(),
-  url: z.url({ message: 'La URL debe ser válida' }).optional()
+export const lugarUpdateSchema = createUpdateSchema(place)
+
+export const lugarSchema = lugarInsertSchema
+
+export const lugarFormSchema = lugarInsertSchema.pick({
+  nombre: true,
+  direccion: true,
+  ciudad: true,
+  coordenadas: true,
+  url: true
 })
 
-/**
- * Tipos TypeScript inferidos desde schemas Zod
- */
-export type EdicionInput = z.infer<typeof edicionSchema>
+export type EdicionInput = z.infer<typeof edicionInsertSchema>
 export type EdicionFormInput = z.infer<typeof edicionFormSchema>
 export type EdicionDiaInput = Omit<
-  z.infer<typeof edicionDiaSchema>,
+  z.infer<typeof edicionDiaInsertSchema>,
   'eventoEdicionId' | 'lugarId'
 > & {
   eventoEdicionId: number
   lugarId?: number
 }
 export type EdicionDiaFormInput = z.infer<typeof edicionDiaFormSchema>
-export type LugarInput = z.infer<typeof lugarSchema>
+export type LugarInput = z.infer<typeof lugarInsertSchema>
 export type LugarFormInput = z.infer<typeof lugarFormSchema>

--- a/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/eventos/ediciones/_types/index.ts
@@ -1,16 +1,16 @@
 import type {
-  EventoEdicion,
-  EventoEdicionDia,
-  Lugar
+  EventEdition,
+  EventEditionDay,
+  Place
 } from '@frijolmagico/database/orm'
 
-export type EdicionEntry = Omit<EventoEdicion, 'id' | 'eventoId'> & {
+export type EdicionEntry = Omit<EventEdition, 'id' | 'eventoId'> & {
   id: string
   eventoId: string
 }
 
 export type EdicionDiaEntry = Omit<
-  EventoEdicionDia,
+  EventEditionDay,
   'id' | 'eventoEdicionId' | 'lugarId'
 > & {
   id: string
@@ -18,7 +18,7 @@ export type EdicionDiaEntry = Omit<
   lugarId: string | null
 }
 
-export type LugarEntry = Omit<Lugar, 'id'> & {
+export type LugarEntry = Omit<Place, 'id'> & {
   id: string
 }
 

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_schemas/organizacion.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_schemas/organizacion.schema.ts
@@ -1,33 +1,36 @@
 import { z } from 'zod'
+import { createInsertSchema, createUpdateSchema } from 'drizzle-zod'
+import { core } from '@frijolmagico/database/schema'
 
-export const organizacionSchema = z.object({
-  id: z.number().int().positive().optional(),
-  nombre: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  descripcion: z.string().optional(),
-  mision: z.string().optional(),
-  vision: z.string().optional()
+const { organization, organizationMember } = core
+
+export const organizacionInsertSchema = createInsertSchema(organization, {
+  nombre: (s) => s.min(1, { message: 'El nombre es obligatorio' })
 })
 
-export const organizacionEquipoSchema = z.object({
-  id: z.number().int().positive().optional(),
-  organizationId: z
-    .number()
-    .int()
-    .positive({ error: 'organizationId debe ser un entero positivo' }),
-  name: z.string().min(1, { error: 'El nombre es obligatorio' }),
-  position: z.string().optional(),
-  rut: z.string().optional(),
-  email: z.string().optional(),
-  phone: z.string().optional(),
-  rrss: z.preprocess((val) => {
-    if (val && typeof val === 'object') return JSON.stringify(val)
-    return val
-  }, z.string().optional())
-})
+export const organizacionUpdateSchema = createUpdateSchema(organization)
+
+export const organizacionEquipoInsertSchema = createInsertSchema(
+  organizationMember,
+  {
+    organizationId: (s) => s.int().positive(),
+    name: (s) => s.min(1, { message: 'El nombre es obligatorio' }),
+    rrss: (s) =>
+      s
+        .transform((val: unknown) => {
+          if (val && typeof val === 'object') return JSON.stringify(val)
+          return val as string | null | undefined
+        })
+        .optional()
+  }
+)
+
+export const organizacionEquipoUpdateSchema =
+  createUpdateSchema(organizationMember)
 
 /**
  * Schema Zod para el formulario de equipo (UI layer)
- * Acepta rrss como Record<string, string> | null para la interfaz de usuario
+ * Acepta rrss como Record<string, string[]> | null para la interfaz de usuario
  */
 export const equipoFormSchema = z.object({
   name: z.string().min(1, 'El nombre es requerido'),
@@ -38,6 +41,27 @@ export const equipoFormSchema = z.object({
   rrss: z.record(z.string(), z.array(z.string())).nullable()
 })
 
-export type OrganizacionInput = z.infer<typeof organizacionSchema>
-export type OrganizacionEquipoInput = z.infer<typeof organizacionEquipoSchema>
+export const organizacionSchema = organizacionInsertSchema
+export const organizacionEquipoSchema = organizacionEquipoInsertSchema
+
+export type OrganizacionInsertInput = z.infer<typeof organizacionInsertSchema>
+export type OrganizacionEquipoInsertInput = z.infer<
+  typeof organizacionEquipoInsertSchema
+>
 export type EquipoFormInput = z.infer<typeof equipoFormSchema>
+
+export type OrganizacionInput = OrganizacionInsertInput
+export type OrganizacionEquipoInput = OrganizacionEquipoInsertInput
+
+export const organizacionFormSchema = organizacionInsertSchema
+  .pick({
+    nombre: true,
+    descripcion: true,
+    mision: true,
+    vision: true
+  })
+  .extend({
+    nombre: z.string().min(1, { message: 'El nombre es obligatorio' })
+  })
+
+export type OrganizacionFormInput = z.infer<typeof organizacionFormSchema>

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_types/index.ts
@@ -1,7 +1,10 @@
-import { Organizacion, OrganizacionEquipo } from '@frijolmagico/database/orm'
+import type {
+  Organization as RawOrg,
+  OrganizationMember
+} from '@frijolmagico/database/orm'
 
-export type RawOrganization = Organizacion
-export type RawTeamMember = OrganizacionEquipo
+export type RawOrganization = RawOrg
+export type RawTeamMember = OrganizationMember
 
 export type Organization = Omit<RawOrganization, 'id'> & {
   id: string
@@ -21,5 +24,5 @@ export type TeamMember = {
 export interface UpdateOrganizationResult {
   success: boolean
   error?: string
-  data?: Organizacion
+  data?: RawOrg
 }

--- a/apps/admin/src/app/(authenticated)/_components/auth-guard.tsx
+++ b/apps/admin/src/app/(authenticated)/_components/auth-guard.tsx
@@ -1,0 +1,6 @@
+import { requireAuth } from '@/lib/auth/utils'
+
+export async function AuthGuard({ children }: { children: React.ReactNode }) {
+  await requireAuth()
+  return <>{children}</>
+}

--- a/apps/admin/src/app/(authenticated)/layout.tsx
+++ b/apps/admin/src/app/(authenticated)/layout.tsx
@@ -1,7 +1,9 @@
+import { Suspense } from 'react'
 import { SidebarProvider } from '@/shared/components/ui/sidebar'
 import { PanelHeader } from '@/shared/components/panel-header'
 import { PanelSidebar } from '@/shared/components/sidebar'
 import { TooltipProvider } from '@/shared/components/ui/tooltip'
+import { AuthGuard } from './_components/auth-guard'
 
 export default function AuthenticatedLayout({
   children
@@ -9,18 +11,22 @@ export default function AuthenticatedLayout({
   children: React.ReactNode
 }) {
   return (
-    <TooltipProvider>
-      <SidebarProvider>
-        <div className='flex min-h-screen w-full'>
-          <PanelSidebar />
-          <div className='flex flex-1 flex-col'>
-            <PanelHeader />
-            <main className='bg-background w-full flex-1 p-6'>
-              {children}
-            </main>
-          </div>
-        </div>
-      </SidebarProvider>
-    </TooltipProvider>
+    <Suspense>
+      <AuthGuard>
+        <TooltipProvider>
+          <SidebarProvider>
+            <div className='flex min-h-screen w-full'>
+              <PanelSidebar />
+              <div className='flex flex-1 flex-col'>
+                <PanelHeader />
+                <main className='bg-background w-full flex-1 p-6'>
+                  {children}
+                </main>
+              </div>
+            </div>
+          </SidebarProvider>
+        </TooltipProvider>
+      </AuthGuard>
+    </Suspense>
   )
 }

--- a/apps/admin/src/lib/auth/index.ts
+++ b/apps/admin/src/lib/auth/index.ts
@@ -26,7 +26,11 @@ export const auth = betterAuth({
   },
   session: {
     expiresIn: SESSION_EXPIRATION_TIME,
-    updateAge: SESSION_UPDATE_AGE
+    updateAge: SESSION_UPDATE_AGE,
+    cookieCache: {
+      enabled: true,
+      maxAge: SESSION_EXPIRATION_TIME
+    }
   },
   hooks: {
     after: createAuthMiddleware(async (ctx) => {

--- a/apps/admin/src/proxy.ts
+++ b/apps/admin/src/proxy.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server'
 import { getSessionCookie } from 'better-auth/cookies'
 
-export async function proxy(request: NextRequest) {
+export default async function proxy(request: NextRequest) {
   const sessionCookie = getSessionCookie(request)
 
   if (!sessionCookie) {

--- a/apps/admin/src/shared/lib/database-entities.ts
+++ b/apps/admin/src/shared/lib/database-entities.ts
@@ -26,7 +26,7 @@ export const ENTITY_LABELS: Record<Entity, string> = {
 
 export const ROUTE_ENTITY_MAP: Partial<Record<string, Entity[]>> = {
   '/general': [ENTITIES.ORGANIZACION, ENTITIES.ORGANIZACION_EQUIPO],
-  '/artistas/listado': [ENTITIES.ARTISTA],
+  '/artistas': [ENTITIES.ARTISTA],
   '/artistas/catalogo': [ENTITIES.CATALOGO_ARTISTA],
   '/eventos': [ENTITIES.EVENTO],
   '/eventos/ediciones': [

--- a/apps/admin/tests/unit/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.test.ts
+++ b/apps/admin/tests/unit/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.test.ts
@@ -1,26 +1,21 @@
 import { describe, test, expect } from 'bun:test'
-import { catalogoArtistaSchema } from '@/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema'
+import { catalogoArtistaInsertSchema } from '@/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema'
 
-describe('catalogoArtistaSchema', () => {
-  test('validates valid data with defaults', () => {
+describe('catalogoArtistaInsertSchema', () => {
+  test('validates valid data', () => {
     const validData = {
       artistaId: 1,
       orden: '001'
     }
 
-    const result = catalogoArtistaSchema.parse(validData)
+    const result = catalogoArtistaInsertSchema.parse(validData)
 
-    expect(result).toEqual({
-      artistaId: 1,
-      orden: '001',
-      destacado: false,
-      activo: true
-    })
+    expect(result.artistaId).toBe(1)
+    expect(result.orden).toBe('001')
   })
 
   test('validates complete data', () => {
     const validData = {
-      id: 1,
       artistaId: 5,
       orden: '010',
       destacado: true,
@@ -28,9 +23,9 @@ describe('catalogoArtistaSchema', () => {
       descripcion: 'Artista destacado del mes'
     }
 
-    const result = catalogoArtistaSchema.parse(validData)
+    const result = catalogoArtistaInsertSchema.parse(validData)
 
-    expect(result).toEqual(validData)
+    expect(result).toMatchObject(validData)
   })
 
   test('rejects invalid artistaId', () => {
@@ -39,7 +34,7 @@ describe('catalogoArtistaSchema', () => {
       orden: '001'
     }
 
-    expect(() => catalogoArtistaSchema.parse(invalidData)).toThrow()
+    expect(() => catalogoArtistaInsertSchema.parse(invalidData)).toThrow()
   })
 
   test('rejects empty order', () => {
@@ -48,7 +43,7 @@ describe('catalogoArtistaSchema', () => {
       orden: ''
     }
 
-    expect(() => catalogoArtistaSchema.parse(invalidData)).toThrow()
+    expect(() => catalogoArtistaInsertSchema.parse(invalidData)).toThrow()
   })
 
   test('rejects non-boolean featured', () => {
@@ -58,17 +53,7 @@ describe('catalogoArtistaSchema', () => {
       destacado: 'true' as unknown as boolean
     }
 
-    expect(() => catalogoArtistaSchema.parse(invalidData)).toThrow()
-  })
-
-  test('rejects non-boolean active', () => {
-    const invalidData = {
-      artistaId: 1,
-      orden: '001',
-      activo: 1 as unknown as boolean
-    }
-
-    expect(() => catalogoArtistaSchema.parse(invalidData)).toThrow()
+    expect(() => catalogoArtistaInsertSchema.parse(invalidData)).toThrow()
   })
 
   test('allows optional description', () => {
@@ -78,7 +63,7 @@ describe('catalogoArtistaSchema', () => {
       descripcion: undefined
     }
 
-    const result = catalogoArtistaSchema.parse(validData)
+    const result = catalogoArtistaInsertSchema.parse(validData)
 
     expect(result.descripcion).toBeUndefined()
   })

--- a/bun.lock
+++ b/bun.lock
@@ -32,6 +32,8 @@
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
         "dexie": "^4.3.0",
+        "drizzle-orm": "^0.45.1",
+        "drizzle-zod": "^0.8.3",
         "fractional-indexing": "^3.2.0",
         "lucide-react": "^0.563.0",
         "next": "^16.1.6",
@@ -106,6 +108,7 @@
       "dependencies": {
         "@libsql/client": "^0.17.0",
         "drizzle-orm": "^0.45.1",
+        "drizzle-zod": "^0.8.3",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -913,6 +916,8 @@
     "drizzle-kit": ["drizzle-kit@0.31.8", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg=="],
 
     "drizzle-orm": ["drizzle-orm@0.45.1", "", { "peerDependencies": { "@aws-sdk/client-rds-data": ">=3", "@cloudflare/workers-types": ">=4", "@electric-sql/pglite": ">=0.2.0", "@libsql/client": ">=0.10.0", "@libsql/client-wasm": ">=0.10.0", "@neondatabase/serverless": ">=0.10.0", "@op-engineering/op-sqlite": ">=2", "@opentelemetry/api": "^1.4.1", "@planetscale/database": ">=1.13", "@prisma/client": "*", "@tidbcloud/serverless": "*", "@types/better-sqlite3": "*", "@types/pg": "*", "@types/sql.js": "*", "@upstash/redis": ">=1.34.7", "@vercel/postgres": ">=0.8.0", "@xata.io/client": "*", "better-sqlite3": ">=7", "bun-types": "*", "expo-sqlite": ">=14.0.0", "gel": ">=2", "knex": "*", "kysely": "*", "mysql2": ">=2", "pg": ">=8", "postgres": ">=3", "sql.js": ">=1", "sqlite3": ">=5" }, "optionalPeers": ["@aws-sdk/client-rds-data", "@cloudflare/workers-types", "@electric-sql/pglite", "@libsql/client", "@libsql/client-wasm", "@neondatabase/serverless", "@op-engineering/op-sqlite", "@opentelemetry/api", "@planetscale/database", "@prisma/client", "@tidbcloud/serverless", "@types/better-sqlite3", "@types/pg", "@types/sql.js", "@upstash/redis", "@vercel/postgres", "@xata.io/client", "better-sqlite3", "bun-types", "expo-sqlite", "gel", "knex", "kysely", "mysql2", "pg", "postgres", "sql.js", "sqlite3"] }, "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA=="],
+
+    "drizzle-zod": ["drizzle-zod@0.8.3", "", { "peerDependencies": { "drizzle-orm": ">=0.36.0", "zod": "^3.25.0 || ^4.0.0" } }, "sha512-66yVOuvGhKJnTdiqj1/Xaaz9/qzOdRJADpDa68enqS6g3t0kpNkwNYjUuaeXgZfO/UWuIM9HIhSlJ6C5ZraMww=="],
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 

--- a/packages/database/migrations/0011_add_telefono_to_artist.sql
+++ b/packages/database/migrations/0011_add_telefono_to_artist.sql
@@ -1,0 +1,23 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Migración: 0011_add_telefono_and_deleted_at
+-- Descripción: Agregar campos telefono y deleted_at a artista
+
+-- ============================================
+-- 1. Agregar columnas directamente (más seguro)
+-- ============================================
+
+ALTER TABLE artista ADD COLUMN telefono TEXT;
+--> statement-breakpoint
+
+ALTER TABLE artista ADD COLUMN deleted_at TEXT;
+--> statement-breakpoint
+
+-- ============================================
+-- 2. Recrear índices (si es necesario)
+-- ============================================
+
+CREATE INDEX IF NOT EXISTS idx_artista_telefono ON artista (telefono);
+--> statement-breakpoint
+
+CREATE INDEX IF NOT EXISTS idx_artista_deleted_at ON artista (deleted_at);

--- a/packages/database/migrations/0012_add_deleted_at_to_artista_historial_and_catalogo.sql
+++ b/packages/database/migrations/0012_add_deleted_at_to_artista_historial_and_catalogo.sql
@@ -1,0 +1,76 @@
+-- Custom SQL migration file, put your code below! --
+
+-- Migration: 0012_add_deleted_at_to_artista_historial_and_catalogo
+-- Description: Add soft delete to artist-dependent tables with automatic triggers
+
+-- ============================================
+-- 1. Add deleted_at column to artista_imagen
+-- ============================================
+
+ALTER TABLE artista_imagen ADD COLUMN deleted_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_artista_imagen_deleted_at ON artista_imagen (deleted_at);
+CREATE INDEX IF NOT EXISTS idx_artista_imagen_artista_deleted ON artista_imagen (artista_id, deleted_at);
+
+-- ============================================
+-- 2. Add deleted_at column to catalogo_artista
+-- ============================================
+
+ALTER TABLE catalogo_artista ADD COLUMN deleted_at TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_catalogo_artista_deleted_at ON catalogo_artista (deleted_at);
+CREATE INDEX IF NOT EXISTS idx_catalogo_artista_artista_deleted ON catalogo_artista (artista_id, deleted_at);
+
+-- ============================================
+-- 3. Triggers for automatic soft delete
+-- ============================================
+
+-- Trigger: mark artista_imagen as deleted when artista is marked as deleted
+CREATE TRIGGER trigger_artista_soft_delete_imagen
+AFTER UPDATE OF deleted_at ON artista
+FOR EACH ROW
+WHEN NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL
+BEGIN
+  UPDATE artista_imagen
+  SET deleted_at = NEW.deleted_at
+  WHERE artista_id = NEW.id
+  AND deleted_at IS NULL;
+END;
+
+-- Trigger: mark catalogo_artista as deleted when artista is marked as deleted
+CREATE TRIGGER trigger_artista_soft_delete_catalogo
+AFTER UPDATE OF deleted_at ON artista
+FOR EACH ROW
+WHEN NEW.deleted_at IS NOT NULL AND OLD.deleted_at IS NULL
+BEGIN
+  UPDATE catalogo_artista
+  SET deleted_at = NEW.deleted_at
+  WHERE artista_id = NEW.id
+  AND deleted_at IS NULL;
+END;
+
+-- ============================================
+-- 4. Triggers for automatic restoration
+-- ============================================
+
+-- Trigger: restore artista_imagen when artista is restored
+CREATE TRIGGER trigger_artista_restore_imagen
+AFTER UPDATE OF deleted_at ON artista
+FOR EACH ROW
+WHEN NEW.deleted_at IS NULL AND OLD.deleted_at IS NOT NULL
+BEGIN
+  UPDATE artista_imagen
+  SET deleted_at = NULL
+  WHERE artista_id = NEW.id;
+END;
+
+-- Trigger: restore catalogo_artista when artista is restored
+CREATE TRIGGER trigger_artista_restore_catalogo
+AFTER UPDATE OF deleted_at ON artista
+FOR EACH ROW
+WHEN NEW.deleted_at IS NULL AND OLD.deleted_at IS NOT NULL
+BEGIN
+  UPDATE catalogo_artista
+  SET deleted_at = NULL
+  WHERE artista_id = NEW.id;
+END;

--- a/packages/database/migrations/0012_add_deleted_at_to_artista_historial_and_catalogo.sql
+++ b/packages/database/migrations/0012_add_deleted_at_to_artista_historial_and_catalogo.sql
@@ -8,18 +8,24 @@
 -- ============================================
 
 ALTER TABLE artista_imagen ADD COLUMN deleted_at TEXT;
+--> statement-breakpoint
 
 CREATE INDEX IF NOT EXISTS idx_artista_imagen_deleted_at ON artista_imagen (deleted_at);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_artista_imagen_artista_deleted ON artista_imagen (artista_id, deleted_at);
+--> statement-breakpoint
 
 -- ============================================
 -- 2. Add deleted_at column to catalogo_artista
 -- ============================================
 
 ALTER TABLE catalogo_artista ADD COLUMN deleted_at TEXT;
+--> statement-breakpoint
 
 CREATE INDEX IF NOT EXISTS idx_catalogo_artista_deleted_at ON catalogo_artista (deleted_at);
+--> statement-breakpoint
 CREATE INDEX IF NOT EXISTS idx_catalogo_artista_artista_deleted ON catalogo_artista (artista_id, deleted_at);
+--> statement-breakpoint
 
 -- ============================================
 -- 3. Triggers for automatic soft delete
@@ -36,6 +42,7 @@ BEGIN
   WHERE artista_id = NEW.id
   AND deleted_at IS NULL;
 END;
+--> statement-breakpoint
 
 -- Trigger: mark catalogo_artista as deleted when artista is marked as deleted
 CREATE TRIGGER trigger_artista_soft_delete_catalogo
@@ -48,6 +55,7 @@ BEGIN
   WHERE artista_id = NEW.id
   AND deleted_at IS NULL;
 END;
+--> statement-breakpoint
 
 -- ============================================
 -- 4. Triggers for automatic restoration
@@ -63,6 +71,7 @@ BEGIN
   SET deleted_at = NULL
   WHERE artista_id = NEW.id;
 END;
+--> statement-breakpoint
 
 -- Trigger: restore catalogo_artista when artista is restored
 CREATE TRIGGER trigger_artista_restore_catalogo

--- a/packages/database/migrations/meta/0011_snapshot.json
+++ b/packages/database/migrations/meta/0011_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "4798c8ef-a01b-4e4c-9fad-3aada53c46e3",
+  "prevId": "c323026f-8ed3-4688-b1fd-b1d2420631cb",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {},
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/0012_snapshot.json
+++ b/packages/database/migrations/meta/0012_snapshot.json
@@ -1,0 +1,14 @@
+{
+  "id": "a3cf2f43-2a35-4e4a-8648-e356de1b7a49",
+  "prevId": "4798c8ef-a01b-4e4c-9fad-3aada53c46e3",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {},
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/database/migrations/meta/_journal.json
+++ b/packages/database/migrations/meta/_journal.json
@@ -78,6 +78,20 @@
       "when": 1771869285017,
       "tag": "0010_recreate_organizacion_equipo_with_better_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 11,
+      "version": "6",
+      "when": 1772661340532,
+      "tag": "0011_add_telefono_to_artist",
+      "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "6",
+      "when": 1772723036014,
+      "tag": "0012_add_deleted_at_to_artista_historial_and_catalogo",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -27,6 +27,7 @@
   "dependencies": {
     "@libsql/client": "^0.17.0",
     "drizzle-orm": "^0.45.1",
+    "drizzle-zod": "^0.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/database/package.json
+++ b/packages/database/package.json
@@ -14,6 +14,10 @@
     "./schema": {
       "types": "./src/db/schema/index.ts",
       "default": "./src/db/schema/index.ts"
+    },
+    "./filters": {
+      "types": "./src/filters.ts",
+      "default": "./src/filters.ts"
     }
   },
   "scripts": {

--- a/packages/database/src/db/relations.ts
+++ b/packages/database/src/db/relations.ts
@@ -8,301 +8,300 @@ import {
 } from './schema/core'
 
 import {
-  evento,
-  eventoEdicion,
-  eventoEdicionMetrica,
-  eventoEdicionPostulacion,
-  eventoEdicionSnapshot
+  event,
+  eventEdition,
+  eventEditionMetric,
+  eventEditionApplication,
+  eventEditionSnapshot,
+  eventEditionDay
 } from './schema/events'
 
-import { eventoEdicionDia } from './schema/events'
-
 import {
-  actividad,
-  eventoEdicionParticipante,
-  modoIngreso,
-  participanteActividad,
-  participanteExposicion,
-  tipoActividad
+  activity,
+  eventEditionParticipant,
+  admissionMode,
+  participantActivity,
+  participantExhibition,
+  activityType
 } from './schema/participations'
 
 import {
-  agrupacion,
-  artista,
-  artistaEstado,
-  artistaHistorial,
-  artistaImagen,
-  catalogoArtista
+  collective,
+  artist,
+  artistStatus,
+  artistHistory,
+  artistImage,
+  catalogArtist
 } from './schema/artist'
 
 // ============================================
 // Core Relations
 // ============================================
 
-export const organizacionRelations = relations(organization, ({ many }) => ({
+export const organizationRelations = relations(organization, ({ many }) => ({
   equipo: many(organizationMember),
-  eventos: many(evento)
+  eventos: many(event)
 }))
 
 export const organizationMemberRelations = relations(
   organizationMember,
   ({ one }) => ({
-    organizacion: one(organization, {
+    organization: one(organization, {
       fields: [organizationMember.organizationId],
       references: [organization.id]
     })
   })
 )
 
-export const lugarRelations = relations(place, ({ many }) => ({
-  diasEvento: many(eventoEdicionDia)
+export const placeRelations = relations(place, ({ many }) => ({
+  diasEvento: many(eventEditionDay)
 }))
 
-export const disciplinaRelations = relations(discipline, ({ many }) => ({
-  postulaciones: many(eventoEdicionPostulacion),
-  exposiciones: many(participanteExposicion)
+export const disciplineRelations = relations(discipline, ({ many }) => ({
+  postulaciones: many(eventEditionApplication),
+  exposiciones: many(participantExhibition)
 }))
 
 // ============================================
-// Artista Relations
+// Artist Relations
 // ============================================
 
-export const artistaEstadoRelations = relations(artistaEstado, ({ many }) => ({
-  artistas: many(artista)
+export const artistStatusRelations = relations(artistStatus, ({ many }) => ({
+  artists: many(artist)
 }))
 
-export const artistaRelations = relations(artista, ({ one, many }) => ({
-  estado: one(artistaEstado, {
-    fields: [artista.estadoId],
-    references: [artistaEstado.id]
+export const artistRelations = relations(artist, ({ one, many }) => ({
+  estado: one(artistStatus, {
+    fields: [artist.estadoId],
+    references: [artistStatus.id]
   }),
-  imagenes: many(artistaImagen),
-  historial: many(artistaHistorial),
-  catalogoArtista: one(catalogoArtista, {
-    fields: [artista.id],
-    references: [catalogoArtista.artistaId]
+  imagenes: many(artistImage),
+  historial: many(artistHistory),
+  catalogoArtista: one(catalogArtist, {
+    fields: [artist.id],
+    references: [catalogArtist.artistaId]
   }),
-  participaciones: many(eventoEdicionParticipante),
-  exposiciones: many(participanteExposicion),
-  actividades: many(participanteActividad)
+  participaciones: many(eventEditionParticipant),
+  exposiciones: many(participantExhibition),
+  actividades: many(participantActivity)
 }))
 
-export const artistaImagenRelations = relations(artistaImagen, ({ one }) => ({
-  artista: one(artista, {
-    fields: [artistaImagen.artistaId],
-    references: [artista.id]
+export const artistImageRelations = relations(artistImage, ({ one }) => ({
+  artist: one(artist, {
+    fields: [artistImage.artistaId],
+    references: [artist.id]
   })
 }))
 
-export const artistaHistorialRelations = relations(
-  artistaHistorial,
+export const artistHistoryRelations = relations(
+  artistHistory,
   ({ one }) => ({
-    artista: one(artista, {
-      fields: [artistaHistorial.artistaId],
-      references: [artista.id]
+    artist: one(artist, {
+      fields: [artistHistory.artistaId],
+      references: [artist.id]
     })
   })
 )
 
-export const catalogoArtistaRelations = relations(
-  catalogoArtista,
+export const catalogArtistRelations = relations(
+  catalogArtist,
   ({ one }) => ({
-    artista: one(artista, {
-      fields: [catalogoArtista.artistaId],
-      references: [artista.id]
+    artist: one(artist, {
+      fields: [catalogArtist.artistaId],
+      references: [artist.id]
     })
   })
 )
 
-export const agrupacionRelations = relations(agrupacion, ({ many }) => ({
-  exposiciones: many(participanteExposicion),
-  actividades: many(participanteActividad)
+export const collectiveRelations = relations(collective, ({ many }) => ({
+  exposiciones: many(participantExhibition),
+  actividades: many(participantActivity)
 }))
 
 // ============================================
-// Evento Relations
+// Event Relations
 // ============================================
 
-export const eventoRelations = relations(evento, ({ one, many }) => ({
+export const eventRelations = relations(event, ({ one, many }) => ({
   organizacion: one(organization, {
-    fields: [evento.organizacionId],
+    fields: [event.organizacionId],
     references: [organization.id]
   }),
-  ediciones: many(eventoEdicion)
+  ediciones: many(eventEdition)
 }))
 
-export const eventoEdicionRelations = relations(
-  eventoEdicion,
+export const eventEditionRelations = relations(
+  eventEdition,
   ({ one, many }) => ({
-    evento: one(evento, {
-      fields: [eventoEdicion.eventoId],
-      references: [evento.id]
+    evento: one(event, {
+      fields: [eventEdition.eventoId],
+      references: [event.id]
     }),
-    dias: many(eventoEdicionDia),
-    metricas: many(eventoEdicionMetrica),
-    snapshots: many(eventoEdicionSnapshot),
-    postulaciones: many(eventoEdicionPostulacion),
-    participantes: many(eventoEdicionParticipante),
-    exposiciones: many(participanteExposicion),
-    actividades: many(participanteActividad)
+    dias: many(eventEditionDay),
+    metricas: many(eventEditionMetric),
+    snapshots: many(eventEditionSnapshot),
+    postulaciones: many(eventEditionApplication),
+    participantes: many(eventEditionParticipant),
+    exposiciones: many(participantExhibition),
+    actividades: many(participantActivity)
   })
 )
 
-export const eventoEdicionDiaRelations = relations(
-  eventoEdicionDia,
+export const eventEditionDayRelations = relations(
+  eventEditionDay,
   ({ one }) => ({
-    eventoEdicion: one(eventoEdicion, {
-      fields: [eventoEdicionDia.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [eventEditionDay.eventoEdicionId],
+      references: [eventEdition.id]
     }),
     lugar: one(place, {
-      fields: [eventoEdicionDia.lugarId],
+      fields: [eventEditionDay.lugarId],
       references: [place.id]
     })
   })
 )
 
-export const eventoEdicionMetricaRelations = relations(
-  eventoEdicionMetrica,
+export const eventEditionMetricRelations = relations(
+  eventEditionMetric,
   ({ one }) => ({
-    eventoEdicion: one(eventoEdicion, {
-      fields: [eventoEdicionMetrica.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [eventEditionMetric.eventoEdicionId],
+      references: [eventEdition.id]
     })
   })
 )
 
-export const eventoEdicionSnapshotRelations = relations(
-  eventoEdicionSnapshot,
+export const eventEditionSnapshotRelations = relations(
+  eventEditionSnapshot,
   ({ one }) => ({
-    eventoEdicion: one(eventoEdicion, {
-      fields: [eventoEdicionSnapshot.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [eventEditionSnapshot.eventoEdicionId],
+      references: [eventEdition.id]
     })
   })
 )
 
-export const eventoEdicionPostulacionRelations = relations(
-  eventoEdicionPostulacion,
+export const eventEditionApplicationRelations = relations(
+  eventEditionApplication,
   ({ one, many }) => ({
-    eventoEdicion: one(eventoEdicion, {
-      fields: [eventoEdicionPostulacion.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [eventEditionApplication.eventoEdicionId],
+      references: [eventEdition.id]
     }),
-    disciplina: one(discipline, {
-      fields: [eventoEdicionPostulacion.disciplinaId],
+    discipline: one(discipline, {
+      fields: [eventEditionApplication.disciplinaId],
       references: [discipline.id]
     }),
-    exposiciones: many(participanteExposicion),
-    actividades: many(participanteActividad)
+    exposiciones: many(participantExhibition),
+    actividades: many(participantActivity)
   })
 )
 
 // ============================================
-// Participante Relations
+// Participant Relations
 // ============================================
 
-export const tipoActividadRelations = relations(tipoActividad, ({ many }) => ({
-  actividades: many(participanteActividad)
+export const activityTypeRelations = relations(activityType, ({ many }) => ({
+  actividades: many(participantActivity)
 }))
 
-export const modoIngresoRelations = relations(modoIngreso, ({ many }) => ({
-  exposiciones: many(participanteExposicion),
-  actividades: many(participanteActividad)
+export const admissionModeRelations = relations(admissionMode, ({ many }) => ({
+  exposiciones: many(participantExhibition),
+  actividades: many(participantActivity)
 }))
 
-export const eventoEdicionParticipanteRelations = relations(
-  eventoEdicionParticipante,
+export const eventEditionParticipantRelations = relations(
+  eventEditionParticipant,
   ({ one, many }) => ({
-    eventoEdicion: one(eventoEdicion, {
-      fields: [eventoEdicionParticipante.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [eventEditionParticipant.eventoEdicionId],
+      references: [eventEdition.id]
     }),
-    artista: one(artista, {
-      fields: [eventoEdicionParticipante.artistaId],
-      references: [artista.id]
+    artist: one(artist, {
+      fields: [eventEditionParticipant.artistaId],
+      references: [artist.id]
     }),
-    exposiciones: many(participanteExposicion),
-    actividades: many(participanteActividad)
+    exposiciones: many(participantExhibition),
+    actividades: many(participantActivity)
   })
 )
 
-export const participanteExposicionRelations = relations(
-  participanteExposicion,
+export const participantExhibitionRelations = relations(
+  participantExhibition,
   ({ one }) => ({
-    artista: one(artista, {
-      fields: [participanteExposicion.artistaId],
-      references: [artista.id]
+    artist: one(artist, {
+      fields: [participantExhibition.artistaId],
+      references: [artist.id]
     }),
-    eventoEdicion: one(eventoEdicion, {
-      fields: [participanteExposicion.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [participantExhibition.eventoEdicionId],
+      references: [eventEdition.id]
     }),
-    postulacion: one(eventoEdicionPostulacion, {
-      fields: [participanteExposicion.postulacionId],
-      references: [eventoEdicionPostulacion.id]
+    postulacion: one(eventEditionApplication, {
+      fields: [participantExhibition.postulacionId],
+      references: [eventEditionApplication.id]
     }),
-    participante: one(eventoEdicionParticipante, {
-      fields: [participanteExposicion.participanteId],
-      references: [eventoEdicionParticipante.id]
+    participant: one(eventEditionParticipant, {
+      fields: [participantExhibition.participanteId],
+      references: [eventEditionParticipant.id]
     }),
-    disciplina: one(discipline, {
-      fields: [participanteExposicion.disciplinaId],
+    discipline: one(discipline, {
+      fields: [participantExhibition.disciplinaId],
       references: [discipline.id]
     }),
-    agrupacion: one(agrupacion, {
-      fields: [participanteExposicion.agrupacionId],
-      references: [agrupacion.id]
+    agrupacion: one(collective, {
+      fields: [participantExhibition.agrupacionId],
+      references: [collective.id]
     }),
-    modoIngreso: one(modoIngreso, {
-      fields: [participanteExposicion.modoIngresoId],
-      references: [modoIngreso.id]
+    modoIngreso: one(admissionMode, {
+      fields: [participantExhibition.modoIngresoId],
+      references: [admissionMode.id]
     })
   })
 )
 
-export const participanteActividadRelations = relations(
-  participanteActividad,
+export const participantActivityRelations = relations(
+  participantActivity,
   ({ one }) => ({
-    artista: one(artista, {
-      fields: [participanteActividad.artistaId],
-      references: [artista.id]
+    artist: one(artist, {
+      fields: [participantActivity.artistaId],
+      references: [artist.id]
     }),
-    eventoEdicion: one(eventoEdicion, {
-      fields: [participanteActividad.eventoEdicionId],
-      references: [eventoEdicion.id]
+    eventoEdicion: one(eventEdition, {
+      fields: [participantActivity.eventoEdicionId],
+      references: [eventEdition.id]
     }),
-    postulacion: one(eventoEdicionPostulacion, {
-      fields: [participanteActividad.postulacionId],
-      references: [eventoEdicionPostulacion.id]
+    postulacion: one(eventEditionApplication, {
+      fields: [participantActivity.postulacionId],
+      references: [eventEditionApplication.id]
     }),
-    participante: one(eventoEdicionParticipante, {
-      fields: [participanteActividad.participanteId],
-      references: [eventoEdicionParticipante.id]
+    participant: one(eventEditionParticipant, {
+      fields: [participantActivity.participanteId],
+      references: [eventEditionParticipant.id]
     }),
-    tipoActividad: one(tipoActividad, {
-      fields: [participanteActividad.tipoActividadId],
-      references: [tipoActividad.id]
+    tipoActividad: one(activityType, {
+      fields: [participantActivity.tipoActividadId],
+      references: [activityType.id]
     }),
-    agrupacion: one(agrupacion, {
-      fields: [participanteActividad.agrupacionId],
-      references: [agrupacion.id]
+    agrupacion: one(collective, {
+      fields: [participantActivity.agrupacionId],
+      references: [collective.id]
     }),
-    modoIngreso: one(modoIngreso, {
-      fields: [participanteActividad.modoIngresoId],
-      references: [modoIngreso.id]
+    modoIngreso: one(admissionMode, {
+      fields: [participantActivity.modoIngresoId],
+      references: [admissionMode.id]
     }),
-    actividad: one(actividad, {
-      fields: [participanteActividad.id],
-      references: [actividad.participanteActividadId]
+    actividad: one(activity, {
+      fields: [participantActivity.id],
+      references: [activity.participanteActividadId]
     })
   })
 )
 
-export const actividadRelations = relations(actividad, ({ one }) => ({
-  participanteActividad: one(participanteActividad, {
-    fields: [actividad.participanteActividadId],
-    references: [participanteActividad.id]
+export const activityRelations = relations(activity, ({ one }) => ({
+  participantActivity: one(participantActivity, {
+    fields: [activity.participanteActividadId],
+    references: [participantActivity.id]
   })
 }))
 

--- a/packages/database/src/db/schema/artist.ts
+++ b/packages/database/src/db/schema/artist.ts
@@ -8,9 +8,9 @@ import {
 } from 'drizzle-orm/sqlite-core'
 
 /**
- * Artista Estado - Catálogo de estados de artistas
+ * Artist Status - Catalog of artist statuses
  */
-export const artistaEstado = sqliteTable('artista_estado', {
+export const artistStatus = sqliteTable('artista_estado', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   slug: text('slug').notNull().unique(),
   createdAt: text('created_at')
@@ -22,16 +22,16 @@ export const artistaEstado = sqliteTable('artista_estado', {
 })
 
 /**
- * Artista - Artistas registrados en el sistema
+ * Artist - Artists registered in the system
  */
-export const artista = sqliteTable(
+export const artist = sqliteTable(
   'artista',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     estadoId: integer('estado_id')
       .notNull()
       .default(1)
-      .references(() => artistaEstado.id),
+      .references(() => artistStatus.id),
     nombre: text('nombre'),
     pseudonimo: text('pseudonimo').notNull().unique(),
     slug: text('slug').notNull().unique(),
@@ -40,6 +40,8 @@ export const artista = sqliteTable(
     rrss: text('rrss'),
     ciudad: text('ciudad'),
     pais: text('pais'),
+    telefono: text('telefono'),
+    deletedAt: text('deleted_at'),
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
@@ -48,28 +50,30 @@ export const artista = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    uniqueIndex('idx_artista_slug').on(table.slug),
-    uniqueIndex('idx_artista_correo_pseudonimo')
+    uniqueIndex('idx_artist_slug').on(table.slug),
+    uniqueIndex('idx_artist_correo_pseudonimo')
       .on(table.correo, table.pseudonimo)
       .where(sql`${table.correo} IS NOT NULL`),
-    index('idx_artista_estado').on(table.estadoId)
+    index('idx_artist_estado').on(table.estadoId),
+    index('idx_artist_deleted_at').on(table.deletedAt)
   ]
 )
 
 /**
- * Artista Imagen - Imágenes asociadas a artistas
+ * Artist Image - Images associated to artists
  */
-export const artistaImagen = sqliteTable(
+export const artistImage = sqliteTable(
   'artista_imagen',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     artistaId: integer('artista_id')
       .notNull()
-      .references(() => artista.id),
+      .references(() => artist.id),
     imagenUrl: text('imagen_url').notNull(),
     tipo: text('tipo', { enum: ['avatar', 'galeria'] }).notNull(),
     orden: integer('orden').notNull().default(1),
     metadata: text('metadata'),
+    deletedAt: text('deleted_at'),
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
@@ -78,21 +82,22 @@ export const artistaImagen = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    index('idx_artista_imagen_artista').on(table.artistaId),
-    index('idx_artista_imagen_artista_tipo').on(table.artistaId, table.tipo)
+    index('idx_artist_image_artista').on(table.artistaId),
+    index('idx_artist_image_artista_tipo').on(table.artistaId, table.tipo),
+    index('idx_artist_image_deleted_at').on(table.deletedAt)
   ]
 )
 
 /**
- * Artista Historial - Historial de cambios de artistas
+ * Artist History - Change history of artists
  */
-export const artistaHistorial = sqliteTable(
+export const artistHistory = sqliteTable(
   'artista_historial',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     artistaId: integer('artista_id')
       .notNull()
-      .references(() => artista.id),
+      .references(() => artist.id),
     pseudonimo: text('pseudonimo'),
     correo: text('correo'),
     rrss: text('rrss'),
@@ -105,30 +110,31 @@ export const artistaHistorial = sqliteTable(
     notas: text('notas')
   },
   (table) => [
-    uniqueIndex('uq_artista_historial_orden').on(table.artistaId, table.orden),
-    index('idx_artista_historial_artista').on(table.artistaId),
-    index('idx_artista_historial_pseudonimo').on(table.pseudonimo),
-    index('idx_artista_historial_orden').on(table.artistaId, table.orden)
+    uniqueIndex('uq_artist_history_orden').on(table.artistaId, table.orden),
+    index('idx_artist_history_artista').on(table.artistaId),
+    index('idx_artist_history_pseudonimo').on(table.pseudonimo),
+    index('idx_artist_history_orden').on(table.artistaId, table.orden)
   ]
 )
 
 /**
- * Catalogo Artista - Artistas en el catálogo público
+ * Catalog Artist - Artists in the public catalog
  */
-export const catalogoArtista = sqliteTable(
+export const catalogArtist = sqliteTable(
   'catalogo_artista',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     artistaId: integer('artista_id')
       .notNull()
       .unique()
-      .references(() => artista.id),
+      .references(() => artist.id),
     orden: text('orden').notNull(),
     destacado: integer('destacado', { mode: 'boolean' })
       .notNull()
       .default(false),
     activo: integer('activo', { mode: 'boolean' }).notNull().default(true),
     descripcion: text('descripcion'),
+    deletedAt: text('deleted_at'),
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
@@ -137,16 +143,17 @@ export const catalogoArtista = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    index('idx_catalogo_artista_orden').on(table.orden),
-    index('idx_catalogo_artista_activo').on(table.activo),
-    index('idx_catalogo_artista_destacado').on(table.destacado)
+    index('idx_catalog_artist_orden').on(table.orden),
+    index('idx_catalog_artist_activo').on(table.activo),
+    index('idx_catalog_artist_destacado').on(table.destacado),
+    index('idx_catalog_artist_deleted_at').on(table.deletedAt)
   ]
 )
 
 /**
- * Agrupacion - Agrupaciones de artistas
+ * Collective - Artist groupings
  */
-export const agrupacion = sqliteTable('agrupacion', {
+export const collective = sqliteTable('agrupacion', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   nombre: text('nombre').unique().notNull(),
   descripcion: text('descripcion'),

--- a/packages/database/src/db/schema/auth.ts
+++ b/packages/database/src/db/schema/auth.ts
@@ -2,7 +2,7 @@ import { sql } from 'drizzle-orm'
 import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
 
 /**
- * User - Usuarios autenticados (Better Auth)
+ * User - Authenticated users (Better Auth)
  */
 export const user = sqliteTable(
   'user',
@@ -25,7 +25,7 @@ export const user = sqliteTable(
 )
 
 /**
- * Session - Sesiones de usuario (Better Auth)
+ * Session - User sessions (Better Auth)
  */
 export const session = sqliteTable(
   'session',
@@ -49,7 +49,7 @@ export const session = sqliteTable(
 )
 
 /**
- * Account - Cuentas OAuth vinculadas (Better Auth)
+ * Account - Linked OAuth accounts (Better Auth)
  */
 export const account = sqliteTable(
   'account',
@@ -81,7 +81,7 @@ export const account = sqliteTable(
 )
 
 /**
- * Verification - Tokens de verificación (Better Auth)
+ * Verification - Verification tokens (Better Auth)
  */
 export const verification = sqliteTable(
   'verification',

--- a/packages/database/src/db/schema/compat.ts
+++ b/packages/database/src/db/schema/compat.ts
@@ -1,0 +1,35 @@
+// Backwards compatibility - export English names as Spanish aliases
+import * as artist from './artist'
+import * as events from './events'
+import * as core from './core'
+import * as participations from './participations'
+
+// Artist exports (English → Spanish aliases)
+export const artista = artist.artist
+export const artistaEstado = artist.artistStatus
+export const artistaImagen = artist.artistImage
+export const artistaHistorial = artist.artistHistory
+export const catalogoArtista = artist.catalogArtist
+export const agrupacion = artist.collective
+
+// Events exports (English → Spanish aliases)
+export const evento = events.event
+export const eventoEdicion = events.eventEdition
+export const eventoEdicionDia = events.eventEditionDay
+export const eventoEdicionMetrica = events.eventEditionMetric
+export const eventoEdicionSnapshot = events.eventEditionSnapshot
+export const eventoEdicionPostulacion = events.eventEditionApplication
+
+// Core exports (keep English as they were)
+export const organization = core.organization
+export const organizationMember = core.organizationMember
+export const place = core.place
+export const discipline = core.discipline
+
+// Participations exports (keep English as they were)
+export const tipoActividad = participations.activityType
+export const modoIngreso = participations.admissionMode
+export const eventoEdicionParticipante = participations.eventEditionParticipant
+export const participanteExposicion = participations.participantExhibition
+export const participanteActividad = participations.participantActivity
+export const actividad = participations.activity

--- a/packages/database/src/db/schema/core.ts
+++ b/packages/database/src/db/schema/core.ts
@@ -7,7 +7,7 @@ import {
 } from 'drizzle-orm/sqlite-core'
 
 /**
- * Organizacion - Entidad organizadora
+ * Organization - Organizing entity
  */
 export const organization = sqliteTable('organizacion', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -24,7 +24,7 @@ export const organization = sqliteTable('organizacion', {
 })
 
 /**
- * Organizacion Equipo - Miembros del equipo de la organización
+ * Organization Member - Team members of the organization
  */
 export const organizationMember = sqliteTable('organization_member', {
   id: integer('id').primaryKey({ autoIncrement: true }),
@@ -46,7 +46,7 @@ export const organizationMember = sqliteTable('organization_member', {
 })
 
 /**
- * Lugar - Ubicaciones donde se realizan eventos
+ * Place - Locations where events take place
  */
 export const place = sqliteTable(
   'lugar',
@@ -70,7 +70,7 @@ export const place = sqliteTable(
 )
 
 /**
- * Disciplina - Catálogo de disciplinas artísticas
+ * Discipline - Catalog of artistic disciplines
  */
 export const discipline = sqliteTable('disciplina', {
   id: integer('id').primaryKey({ autoIncrement: true }),

--- a/packages/database/src/db/schema/events.ts
+++ b/packages/database/src/db/schema/events.ts
@@ -11,9 +11,9 @@ import {
 import { discipline, place, organization } from './core'
 
 /**
- * Evento - Eventos organizados
+ * Event - Organized events
  */
-export const evento = sqliteTable(
+export const event = sqliteTable(
   'evento',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
@@ -33,17 +33,17 @@ export const evento = sqliteTable(
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`)
   },
-  (table) => [uniqueIndex('idx_evento_slug').on(table.slug)]
+  (table) => [uniqueIndex('idx_event_slug').on(table.slug)]
 )
 
 /**
- * Evento Edicion - Ediciones de un evento
+ * Event Edition - Editions of an event
  */
-export const eventoEdicion = sqliteTable(
+export const eventEdition = sqliteTable(
   'evento_edicion',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
-    eventoId: integer('evento_id').references(() => evento.id, {
+    eventoId: integer('evento_id').references(() => event.id, {
       onDelete: 'set null'
     }),
     nombre: text('nombre'),
@@ -58,25 +58,25 @@ export const eventoEdicion = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    uniqueIndex('idx_evento_edicion_numero').on(
+    uniqueIndex('idx_event_edition_numero').on(
       table.eventoId,
       table.numeroEdicion
     ),
-    uniqueIndex('idx_evento_edicion_slug').on(table.eventoId, table.slug),
-    index('idx_evento_edicion_evento').on(table.eventoId)
+    uniqueIndex('idx_event_edition_slug').on(table.eventoId, table.slug),
+    index('idx_event_edition_evento').on(table.eventoId)
   ]
 )
 
 /**
- * Evento Edicion Dia - Días de una edición de evento
+ * Event Edition Day - Days of an event edition
  */
-export const eventoEdicionDia = sqliteTable(
+export const eventEditionDay = sqliteTable(
   'evento_edicion_dia',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     eventoEdicionId: integer('evento_edicion_id')
       .notNull()
-      .references(() => eventoEdicion.id, { onDelete: 'cascade' }),
+      .references(() => eventEdition.id, { onDelete: 'cascade' }),
     lugarId: integer('lugar_id').references(() => place.id, {
       onDelete: 'set null'
     }),
@@ -94,22 +94,22 @@ export const eventoEdicionDia = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    uniqueIndex('uq_evento_edicion_dia').on(table.eventoEdicionId, table.fecha),
-    index('idx_evento_edicion_dia_edicion').on(table.eventoEdicionId),
-    index('idx_evento_edicion_dia_fecha').on(table.fecha),
-    index('idx_evento_edicion_dia_lugar').on(table.lugarId)
+    uniqueIndex('uq_event_edition_day').on(table.eventoEdicionId, table.fecha),
+    index('idx_event_edition_day_edicion').on(table.eventoEdicionId),
+    index('idx_event_edition_day_fecha').on(table.fecha),
+    index('idx_event_edition_day_lugar').on(table.lugarId)
   ]
 )
 
 /**
- * Evento Edicion Metrica - Métricas de ediciones de eventos
+ * Event Edition Metric - Metrics of event editions
  */
-export const eventoEdicionMetrica = sqliteTable(
+export const eventEditionMetric = sqliteTable(
   'evento_edicion_metrica',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     eventoEdicionId: integer('evento_edicion_id').references(
-      () => eventoEdicion.id,
+      () => eventEdition.id,
       {
         onDelete: 'set null'
       }
@@ -124,22 +124,20 @@ export const eventoEdicionMetrica = sqliteTable(
     notas: text('notas')
   },
   (table) => [
-    index('idx_evento_edicion_metrica_evento_edicion').on(
-      table.eventoEdicionId
-    ),
-    index('idx_evento_edicion_metrica_fecha').on(table.fechaRegistro)
+    index('idx_event_edition_metric_evento_edicion').on(table.eventoEdicionId),
+    index('idx_event_edition_metric_fecha').on(table.fechaRegistro)
   ]
 )
 
 /**
- * Evento Edicion Snapshot - Snapshots de ediciones de eventos
+ * Event Edition Snapshot - Snapshots of event editions
  */
-export const eventoEdicionSnapshot = sqliteTable(
+export const eventEditionSnapshot = sqliteTable(
   'evento_edicion_snapshot',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     eventoEdicionId: integer('evento_edicion_id').references(
-      () => eventoEdicion.id,
+      () => eventEdition.id,
       {
         onDelete: 'set null'
       }
@@ -153,22 +151,20 @@ export const eventoEdicionSnapshot = sqliteTable(
   },
   (table) => [
     uniqueIndex('uq_snapshot').on(table.eventoEdicionId, table.tipo),
-    index('idx_evento_edicion_snapshot_evento_edicion').on(
-      table.eventoEdicionId
-    )
+    index('idx_event_edition_snapshot_evento_edicion').on(table.eventoEdicionId)
   ]
 )
 
 /**
- * Evento Edicion Postulacion - Postulaciones a ediciones de eventos
+ * Event Edition Application - Applications to event editions
  */
-export const eventoEdicionPostulacion = sqliteTable(
+export const eventEditionApplication = sqliteTable(
   'evento_edicion_postulacion',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     eventoEdicionId: integer('evento_edicion_id')
       .notNull()
-      .references(() => eventoEdicion.id, { onDelete: 'cascade' }),
+      .references(() => eventEdition.id, { onDelete: 'cascade' }),
     nombre: text('nombre').notNull(),
     pseudonimo: text('pseudonimo'),
     correo: text('correo'),
@@ -190,7 +186,7 @@ export const eventoEdicionPostulacion = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    index('idx_postulacion_evento_edicion').on(table.eventoEdicionId),
-    index('idx_postulacion_disciplina').on(table.disciplinaId)
+    index('idx_application_evento_edicion').on(table.eventoEdicionId),
+    index('idx_application_disciplina').on(table.disciplinaId)
   ]
 )

--- a/packages/database/src/db/schema/participations.ts
+++ b/packages/database/src/db/schema/participations.ts
@@ -7,14 +7,14 @@ import {
   uniqueIndex
 } from 'drizzle-orm/sqlite-core'
 
-import { eventoEdicion, eventoEdicionPostulacion } from './events'
-import { agrupacion, artista } from './artist'
+import { eventEdition, eventEditionApplication } from './events'
+import { collective, artist } from './artist'
 import { discipline } from './core'
 
 /**
- * Tipo Actividad - Catálogo de tipos de actividades
+ * Activity Type - Catalog of activity types
  */
-export const tipoActividad = sqliteTable('tipo_actividad', {
+export const activityType = sqliteTable('tipo_actividad', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   slug: text('slug').notNull().unique(),
   descripcion: text('descripcion'),
@@ -27,9 +27,9 @@ export const tipoActividad = sqliteTable('tipo_actividad', {
 })
 
 /**
- * Modo Ingreso - Catálogo de modos de ingreso de participantes
+ * Admission Mode - Catalog of admission modes for participants
  */
-export const modoIngreso = sqliteTable('modo_ingreso', {
+export const admissionMode = sqliteTable('modo_ingreso', {
   id: integer('id').primaryKey({ autoIncrement: true }),
   slug: text('slug').notNull().unique(),
   descripcion: text('descripcion'),
@@ -42,18 +42,18 @@ export const modoIngreso = sqliteTable('modo_ingreso', {
 })
 
 /**
- * Evento Edicion Participante - Participantes en ediciones de eventos (tabla maestra)
+ * Event Edition Participant - Participants in event editions (master table)
  */
-export const eventoEdicionParticipante = sqliteTable(
+export const eventEditionParticipant = sqliteTable(
   'evento_edicion_participante',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     eventoEdicionId: integer('evento_edicion_id')
       .notNull()
-      .references(() => eventoEdicion.id, { onDelete: 'cascade' }),
+      .references(() => eventEdition.id, { onDelete: 'cascade' }),
     artistaId: integer('artista_id')
       .notNull()
-      .references(() => artista.id, { onDelete: 'cascade' }),
+      .references(() => artist.id, { onDelete: 'cascade' }),
     estado: text('estado', {
       enum: ['renuncia', 'expulsado', 'cancelado', 'activo', 'completado']
     })
@@ -68,42 +68,42 @@ export const eventoEdicionParticipante = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    uniqueIndex('uq_participante').on(table.artistaId, table.eventoEdicionId),
-    index('idx_participante_evento_edicion').on(table.eventoEdicionId),
-    index('idx_participante_artista').on(table.artistaId),
-    index('idx_participante_estado').on(table.estado)
+    uniqueIndex('uq_participant').on(table.artistaId, table.eventoEdicionId),
+    index('idx_participant_evento_edicion').on(table.eventoEdicionId),
+    index('idx_participant_artista').on(table.artistaId),
+    index('idx_participant_estado').on(table.estado)
   ]
 )
 
 /**
- * Participante Exposicion - Participantes en sección de exposición
+ * Participant Exhibition - Participants in exhibition section
  */
-export const participanteExposicion = sqliteTable(
+export const participantExhibition = sqliteTable(
   'participante_exposicion',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     artistaId: integer('artista_id')
       .notNull()
-      .references(() => artista.id, { onDelete: 'restrict' }),
+      .references(() => artist.id, { onDelete: 'restrict' }),
     eventoEdicionId: integer('evento_edicion_id')
       .notNull()
-      .references(() => eventoEdicion.id, { onDelete: 'restrict' }),
+      .references(() => eventEdition.id, { onDelete: 'restrict' }),
     postulacionId: integer('postulacion_id').references(
-      () => eventoEdicionPostulacion.id,
+      () => eventEditionApplication.id,
       { onDelete: 'restrict' }
     ),
     participanteId: integer('participante_id').references(
-      () => eventoEdicionParticipante.id,
+      () => eventEditionParticipant.id,
       { onDelete: 'restrict' }
     ),
     disciplinaId: integer('disciplina_id')
       .notNull()
       .references(() => discipline.id),
-    agrupacionId: integer('agrupacion_id').references(() => agrupacion.id),
+    agrupacionId: integer('agrupacion_id').references(() => collective.id),
     modoIngresoId: integer('modo_ingreso_id')
       .notNull()
       .default(1)
-      .references(() => modoIngreso.id),
+      .references(() => admissionMode.id),
     puntaje: integer('puntaje'),
     estado: text('estado', {
       enum: [
@@ -126,53 +126,53 @@ export const participanteExposicion = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    uniqueIndex('uq_exposicion_artista_evento').on(
+    uniqueIndex('uq_exhibition_artista_evento').on(
       table.artistaId,
       table.eventoEdicionId
     ),
-    index('idx_exposicion_artista').on(table.artistaId),
-    index('idx_exposicion_evento_edicion').on(table.eventoEdicionId),
-    index('idx_exposicion_postulacion').on(table.postulacionId),
-    index('idx_exposicion_participante').on(table.participanteId),
-    index('idx_exposicion_estado').on(table.estado),
-    index('idx_exposicion_disciplina').on(table.disciplinaId),
-    index('idx_exposicion_agrupacion').on(table.agrupacionId),
-    index('idx_exposicion_modo_ingreso').on(table.modoIngresoId),
-    index('idx_exposicion_puntaje')
+    index('idx_exhibition_artista').on(table.artistaId),
+    index('idx_exhibition_evento_edicion').on(table.eventoEdicionId),
+    index('idx_exhibition_postulacion').on(table.postulacionId),
+    index('idx_exhibition_participante').on(table.participanteId),
+    index('idx_exhibition_estado').on(table.estado),
+    index('idx_exhibition_disciplina').on(table.disciplinaId),
+    index('idx_exhibition_agrupacion').on(table.agrupacionId),
+    index('idx_exhibition_modo_ingreso').on(table.modoIngresoId),
+    index('idx_exhibition_puntaje')
       .on(table.puntaje)
       .where(sql`${table.puntaje} IS NOT NULL`)
   ]
 )
 
 /**
- * Participante Actividad - Participantes en actividades
+ * Participant Activity - Participants in activities
  */
-export const participanteActividad = sqliteTable(
+export const participantActivity = sqliteTable(
   'participante_actividad',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     artistaId: integer('artista_id')
       .notNull()
-      .references(() => artista.id, { onDelete: 'restrict' }),
+      .references(() => artist.id, { onDelete: 'restrict' }),
     eventoEdicionId: integer('evento_edicion_id')
       .notNull()
-      .references(() => eventoEdicion.id, { onDelete: 'restrict' }),
+      .references(() => eventEdition.id, { onDelete: 'restrict' }),
     postulacionId: integer('postulacion_id').references(
-      () => eventoEdicionPostulacion.id,
+      () => eventEditionApplication.id,
       { onDelete: 'restrict' }
     ),
     participanteId: integer('participante_id').references(
-      () => eventoEdicionParticipante.id,
+      () => eventEditionParticipant.id,
       { onDelete: 'restrict' }
     ),
     tipoActividadId: integer('tipo_actividad_id')
       .notNull()
-      .references(() => tipoActividad.id),
-    agrupacionId: integer('agrupacion_id').references(() => agrupacion.id),
+      .references(() => activityType.id),
+    agrupacionId: integer('agrupacion_id').references(() => collective.id),
     modoIngresoId: integer('modo_ingreso_id')
       .notNull()
       .default(2)
-      .references(() => modoIngreso.id),
+      .references(() => admissionMode.id),
     puntaje: integer('puntaje'),
     estado: text('estado', {
       enum: [
@@ -195,31 +195,31 @@ export const participanteActividad = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    index('idx_actividad_artista').on(table.artistaId),
-    index('idx_actividad_evento_edicion').on(table.eventoEdicionId),
-    index('idx_actividad_postulacion').on(table.postulacionId),
-    index('idx_actividad_participante').on(table.participanteId),
-    index('idx_actividad_estado').on(table.estado),
-    index('idx_actividad_tipo_actividad').on(table.tipoActividadId),
-    index('idx_actividad_agrupacion').on(table.agrupacionId),
-    index('idx_actividad_modo_ingreso').on(table.modoIngresoId),
-    index('idx_actividad_puntaje')
+    index('idx_activity_artista').on(table.artistaId),
+    index('idx_activity_evento_edicion').on(table.eventoEdicionId),
+    index('idx_activity_postulacion').on(table.postulacionId),
+    index('idx_activity_participante').on(table.participanteId),
+    index('idx_activity_estado').on(table.estado),
+    index('idx_activity_tipo_actividad').on(table.tipoActividadId),
+    index('idx_activity_agrupacion').on(table.agrupacionId),
+    index('idx_activity_modo_ingreso').on(table.modoIngresoId),
+    index('idx_activity_puntaje')
       .on(table.puntaje)
       .where(sql`${table.puntaje} IS NOT NULL`)
   ]
 )
 
 /**
- * Actividad - Detalles de actividades programadas
+ * Activity - Details of scheduled activities
  */
-export const actividad = sqliteTable(
+export const activity = sqliteTable(
   'actividad',
   {
     id: integer('id').primaryKey({ autoIncrement: true }),
     participanteActividadId: integer('participante_actividad_id')
       .unique()
       .notNull()
-      .references(() => participanteActividad.id, { onDelete: 'cascade' }),
+      .references(() => participantActivity.id, { onDelete: 'cascade' }),
     titulo: text('titulo'),
     descripcion: text('descripcion'),
     duracionMinutos: integer('duracion_minutos'),
@@ -234,8 +234,6 @@ export const actividad = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`)
   },
   (table) => [
-    index('idx_actividad_participante_actividad').on(
-      table.participanteActividadId
-    )
+    index('idx_activity_participante_actividad').on(table.participanteActividadId)
   ]
 )

--- a/packages/database/src/db/types.ts
+++ b/packages/database/src/db/types.ts
@@ -8,31 +8,30 @@ import {
 } from './schema/core'
 
 import {
-  evento,
-  eventoEdicion,
-  eventoEdicionMetrica,
-  eventoEdicionPostulacion,
-  eventoEdicionSnapshot
+  event,
+  eventEdition,
+  eventEditionMetric,
+  eventEditionApplication,
+  eventEditionSnapshot,
+  eventEditionDay
 } from './schema/events'
 
-import { eventoEdicionDia } from './schema/events'
-
 import {
-  actividad,
-  eventoEdicionParticipante,
-  modoIngreso,
-  participanteActividad,
-  participanteExposicion,
-  tipoActividad
+  activity,
+  eventEditionParticipant,
+  admissionMode,
+  participantActivity,
+  participantExhibition,
+  activityType
 } from './schema/participations'
 
 import {
-  agrupacion,
-  artista,
-  artistaEstado,
-  artistaHistorial,
-  artistaImagen,
-  catalogoArtista
+  collective,
+  artist,
+  artistStatus,
+  artistHistory,
+  artistImage,
+  catalogArtist
 } from './schema/artist'
 
 import { account, session, user, verification } from './schema/auth'
@@ -41,105 +40,105 @@ import { account, session, user, verification } from './schema/auth'
 // Core Types
 // ============================================
 
-export type Organizacion = InferSelectModel<typeof organization>
-export type NewOrganizacion = InferInsertModel<typeof organization>
+export type Organization = InferSelectModel<typeof organization>
+export type NewOrganization = InferInsertModel<typeof organization>
 
-export type OrganizacionEquipo = InferSelectModel<typeof organizationMember>
-export type NewOrganizacionEquipo = InferInsertModel<typeof organizationMember>
+export type OrganizationMember = InferSelectModel<typeof organizationMember>
+export type NewOrganizationMember = InferInsertModel<typeof organizationMember>
 
-export type Lugar = InferSelectModel<typeof place>
-export type NewLugar = InferInsertModel<typeof place>
+export type Place = InferSelectModel<typeof place>
+export type NewPlace = InferInsertModel<typeof place>
 
-export type Disciplina = InferSelectModel<typeof discipline>
-export type NewDisciplina = InferInsertModel<typeof discipline>
-
-// ============================================
-// Artista Types
-// ============================================
-
-export type ArtistaEstado = InferSelectModel<typeof artistaEstado>
-export type NewArtistaEstado = InferInsertModel<typeof artistaEstado>
-
-export type Artista = InferSelectModel<typeof artista>
-export type NewArtista = InferInsertModel<typeof artista>
-
-export type ArtistaImagen = InferSelectModel<typeof artistaImagen>
-export type NewArtistaImagen = InferInsertModel<typeof artistaImagen>
-
-export type ArtistaHistorial = InferSelectModel<typeof artistaHistorial>
-export type NewArtistaHistorial = InferInsertModel<typeof artistaHistorial>
-
-export type CatalogoArtista = InferSelectModel<typeof catalogoArtista>
-export type NewCatalogoArtista = InferInsertModel<typeof catalogoArtista>
-
-export type Agrupacion = InferSelectModel<typeof agrupacion>
-export type NewAgrupacion = InferInsertModel<typeof agrupacion>
+export type Discipline = InferSelectModel<typeof discipline>
+export type NewDiscipline = InferInsertModel<typeof discipline>
 
 // ============================================
-// Evento Types
+// Artist Types
 // ============================================
 
-export type Evento = InferSelectModel<typeof evento>
-export type NewEvento = InferInsertModel<typeof evento>
+export type ArtistStatus = InferSelectModel<typeof artistStatus>
+export type NewArtistStatus = InferInsertModel<typeof artistStatus>
 
-export type EventoEdicion = InferSelectModel<typeof eventoEdicion>
-export type NewEventoEdicion = InferInsertModel<typeof eventoEdicion>
+export type Artist = InferSelectModel<typeof artist>
+export type NewArtist = InferInsertModel<typeof artist>
 
-export type EventoEdicionDia = InferSelectModel<typeof eventoEdicionDia>
-export type NewEventoEdicionDia = InferInsertModel<typeof eventoEdicionDia>
+export type ArtistImage = InferSelectModel<typeof artistImage>
+export type NewArtistImage = InferInsertModel<typeof artistImage>
 
-export type EventoEdicionMetrica = InferSelectModel<typeof eventoEdicionMetrica>
-export type NewEventoEdicionMetrica = InferInsertModel<
-  typeof eventoEdicionMetrica
+export type ArtistHistory = InferSelectModel<typeof artistHistory>
+export type NewArtistHistory = InferInsertModel<typeof artistHistory>
+
+export type CatalogArtist = InferSelectModel<typeof catalogArtist>
+export type NewCatalogArtist = InferInsertModel<typeof catalogArtist>
+
+export type Collective = InferSelectModel<typeof collective>
+export type NewCollective = InferInsertModel<typeof collective>
+
+// ============================================
+// Event Types
+// ============================================
+
+export type Event = InferSelectModel<typeof event>
+export type NewEvent = InferInsertModel<typeof event>
+
+export type EventEdition = InferSelectModel<typeof eventEdition>
+export type NewEventEdition = InferInsertModel<typeof eventEdition>
+
+export type EventEditionDay = InferSelectModel<typeof eventEditionDay>
+export type NewEventEditionDay = InferInsertModel<typeof eventEditionDay>
+
+export type EventEditionMetric = InferSelectModel<typeof eventEditionMetric>
+export type NewEventEditionMetric = InferInsertModel<
+  typeof eventEditionMetric
 >
 
-export type EventoEdicionSnapshot = InferSelectModel<
-  typeof eventoEdicionSnapshot
+export type EventEditionSnapshot = InferSelectModel<
+  typeof eventEditionSnapshot
 >
-export type NewEventoEdicionSnapshot = InferInsertModel<
-  typeof eventoEdicionSnapshot
+export type NewEventEditionSnapshot = InferInsertModel<
+  typeof eventEditionSnapshot
 >
 
-export type EventoEdicionPostulacion = InferSelectModel<
-  typeof eventoEdicionPostulacion
+export type EventEditionApplication = InferSelectModel<
+  typeof eventEditionApplication
 >
-export type NewEventoEdicionPostulacion = InferInsertModel<
-  typeof eventoEdicionPostulacion
+export type NewEventEditionApplication = InferInsertModel<
+  typeof eventEditionApplication
 >
 
 // ============================================
-// Participante Types
+// Participant Types
 // ============================================
 
-export type TipoActividad = InferSelectModel<typeof tipoActividad>
-export type NewTipoActividad = InferInsertModel<typeof tipoActividad>
+export type ActivityType = InferSelectModel<typeof activityType>
+export type NewActivityType = InferInsertModel<typeof activityType>
 
-export type ModoIngreso = InferSelectModel<typeof modoIngreso>
-export type NewModoIngreso = InferInsertModel<typeof modoIngreso>
+export type AdmissionMode = InferSelectModel<typeof admissionMode>
+export type NewAdmissionMode = InferInsertModel<typeof admissionMode>
 
-export type EventoEdicionParticipante = InferSelectModel<
-  typeof eventoEdicionParticipante
+export type EventEditionParticipant = InferSelectModel<
+  typeof eventEditionParticipant
 >
-export type NewEventoEdicionParticipante = InferInsertModel<
-  typeof eventoEdicionParticipante
->
-
-export type ParticipanteExposicion = InferSelectModel<
-  typeof participanteExposicion
->
-export type NewParticipanteExposicion = InferInsertModel<
-  typeof participanteExposicion
+export type NewEventEditionParticipant = InferInsertModel<
+  typeof eventEditionParticipant
 >
 
-export type ParticipanteActividad = InferSelectModel<
-  typeof participanteActividad
+export type ParticipantExhibition = InferSelectModel<
+  typeof participantExhibition
 >
-export type NewParticipanteActividad = InferInsertModel<
-  typeof participanteActividad
+export type NewParticipantExhibition = InferInsertModel<
+  typeof participantExhibition
 >
 
-export type Actividad = InferSelectModel<typeof actividad>
-export type NewActividad = InferInsertModel<typeof actividad>
+export type ParticipantActivity = InferSelectModel<
+  typeof participantActivity
+>
+export type NewParticipantActivity = InferInsertModel<
+  typeof participantActivity
+>
+
+export type Activity = InferSelectModel<typeof activity>
+export type NewActivity = InferInsertModel<typeof activity>
 
 // ============================================
 // Auth Types

--- a/packages/database/src/filters.ts
+++ b/packages/database/src/filters.ts
@@ -1,0 +1,15 @@
+import { isNull } from 'drizzle-orm'
+import type { AnyColumn, SQL, SQLWrapper } from 'drizzle-orm'
+
+/**
+ * Soft-delete filter predicate.
+ * Returns IS NULL check for the given deleted_at column.
+ * Use in WHERE clauses to exclude soft-deleted records.
+ *
+ * @example
+ * .where(isNotDeleted(artistTable.deletedAt))
+ * .where(and(eq(table.id, id), isNotDeleted(table.deletedAt)))
+ */
+export function isNotDeleted(column: SQLWrapper | AnyColumn): SQL {
+  return isNull(column)
+}


### PR DESCRIPTION
## Summary

- Add `isNotDeleted()` shared helper to `@frijolmagico/database/filters` for soft-delete filtering
- Replace hard deletes (`tx.delete()`) with soft deletes (`tx.update().set({ deletedAt })`) in `save-artista.action.ts` and `save-catalogo.action.ts`
- Add `WHERE deleted_at IS NULL` filters to `get-artists-data.ts` and `get-catalog-data.ts`
- Fix catalog LEFT JOIN to exclude soft-deleted avatar images
- Sync Drizzle schema with DB: add missing `deletedAt` columns to `artista`, `artistaImagen`, `catalogoArtista`

## Details

### Soft Delete Pattern
All DELETE handlers now use Option B guard:
```typescript
await tx.update(table)
  .set({ deletedAt: new Date().toISOString() })
  .where(and(eq(table.id, id), isNotDeleted(table.deletedAt)))
```
- `isNotDeleted(column)` wraps `isNull(column)` — prevents double-delete (idempotent no-op if already soft-deleted)
- DB triggers on `artista` auto-cascade `deleted_at` to `artista_imagen` and `catalogo_artista`

### RESTORE Handlers
Unchanged — remain as `continue` (no-op). RESTORE is a client-side cancellation mechanism: DELETE + RESTORE cancel each other in the operation resolver before reaching the server.

### What's NOT Changed
- Eventos feature (hard deletes correct — FK CASCADE/SET NULL)
- `artista_historial` (no `deleted_at` column)
- Shared push/operation infrastructure
- Any client-side code (stores, hooks, UI already support delete/restore semantics)

### Known Technical Debt
- `apps/web` progressively migrates to DB — DAL queries there will need `isNotDeleted()` filters as they adopt `@frijolmagico/database`

## Verification
- ✅ `bun run type-check` — clean (admin + database)
- ✅ `bun run lint` — clean
- ✅ `bun test` — 102 pass, 0 fail
- ✅ Zero `tx.delete()` calls remain for artista/imagen/catalogo
- ✅ `isNotDeleted` present in all 4 admin files