### PR TITLE
feat(artistas): add per-field historial archive on artist update

### DIFF
--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
@@ -150,9 +150,12 @@ export async function saveArtistaAction(
                 pseudonimo:
                   (historialPayload.pseudonimo as string | undefined) ?? null,
                 correo: (historialPayload.correo as string | undefined) ?? null,
-                rrss: historialPayload.rrss
-                  ? JSON.stringify(historialPayload.rrss)
-                  : null,
+                rrss:
+                  historialPayload.rrss == null
+                    ? null
+                    : typeof historialPayload.rrss === 'string'
+                      ? historialPayload.rrss
+                      : JSON.stringify(historialPayload.rrss),
                 ciudad: (historialPayload.ciudad as string | undefined) ?? null,
                 pais: (historialPayload.pais as string | undefined) ?? null,
                 notas: null

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_actions/save-artista.action.ts
@@ -1,7 +1,7 @@
 'use server'
 
 import { updateTag } from 'next/cache'
-import { ARTISTA_CACHE_TAG } from '../_constants'
+import { ARTISTA_CACHE_TAG, ARTISTA_HISTORIAL_CACHE_TAG } from '../_constants'
 import { db } from '@frijolmagico/database/orm'
 import { artist } from '@frijolmagico/database/schema'
 import { and, eq, sql } from 'drizzle-orm'
@@ -37,6 +37,7 @@ import {
 
 const artistTable = artist.artist
 const artistImageTable = artist.artistImage
+const artistHistoryTable = artist.artistHistory
 
 /**
  * Save artista section changes to database
@@ -100,8 +101,9 @@ export async function saveArtistaAction(
         } else {
           const isUpdate = op.type === PUSH_OPERATION_TYPE.UPDATE
           const schema = isUpdate ? artistaUpdateSchema : artistaInsertSchema
+          const { _historialData, ...operationData } = op.data
           const validated = validateOperationData(
-            op.data,
+            operationData,
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
             schema as any,
             isUpdate
@@ -128,6 +130,34 @@ export async function saveArtistaAction(
               .update(artistTable)
               .set(stripUndefined(input))
               .where(eq(artistTable.id, Number(op.entityId)))
+
+            if (
+              _historialData &&
+              typeof _historialData === 'object' &&
+              Object.keys(_historialData as object).length > 0
+            ) {
+              const historialPayload = _historialData as Record<string, unknown>
+              const [maxResult] = await tx
+                .select({
+                  maxOrden: sql<number>`COALESCE(MAX(${artistHistoryTable.orden}), 0)`
+                })
+                .from(artistHistoryTable)
+                .where(eq(artistHistoryTable.artistaId, Number(op.entityId)))
+
+              await tx.insert(artistHistoryTable).values({
+                artistaId: Number(op.entityId),
+                orden: (maxResult?.maxOrden ?? 0) + 1,
+                pseudonimo:
+                  (historialPayload.pseudonimo as string | undefined) ?? null,
+                correo: (historialPayload.correo as string | undefined) ?? null,
+                rrss: historialPayload.rrss
+                  ? JSON.stringify(historialPayload.rrss)
+                  : null,
+                ciudad: (historialPayload.ciudad as string | undefined) ?? null,
+                pais: (historialPayload.pais as string | undefined) ?? null,
+                notas: null
+              })
+            }
           }
         }
       }
@@ -205,6 +235,7 @@ export async function saveArtistaAction(
     })
 
     updateTag(ARTISTA_CACHE_TAG)
+    updateTag(ARTISTA_HISTORIAL_CACHE_TAG)
 
     return {
       success: true,

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
@@ -22,8 +22,10 @@ import {
 } from '../_store/artista-ui-store'
 import { useArtistDialog } from '../_store/artist-dialog-store'
 import { ArtistRRSSManager } from '../catalogo/_components/artist-rrss-manager'
-import { ArtistEntry } from '../_types'
+import type { ArtistEntry } from '../_types'
 import { Field, FieldGroup, FieldLabel } from '@/shared/components/ui/field'
+import { Switch } from '@/shared/components/ui/switch'
+import { Label } from '@/shared/components/ui/label'
 
 export function EditFormContent({
   artist,
@@ -43,6 +45,26 @@ export function EditFormContent({
     country: artist.pais ?? '',
     statusId: artist.estadoId
   })
+
+  const [historialChecks, setHistorialChecks] = useState({
+    pseudonimo: false,
+    correo: false,
+    rrss: false,
+    ciudad: false,
+    pais: false
+  })
+
+  const hasChanged = {
+    pseudonimo:
+      formData.pseudonimo !== (artist.pseudonimo ?? '') &&
+      Boolean(artist.pseudonimo),
+    correo: formData.correo !== (artist.correo ?? '') && Boolean(artist.correo),
+    rrss:
+      JSON.stringify(formData.rrss) !== JSON.stringify(artist.rrss ?? {}) &&
+      Object.keys(artist.rrss ?? {}).length > 0,
+    ciudad: formData.city !== (artist.ciudad ?? '') && Boolean(artist.ciudad),
+    pais: formData.country !== (artist.pais ?? '') && Boolean(artist.pais)
+  }
 
   const updateField = (
     field: keyof typeof formData,
@@ -64,6 +86,28 @@ export function EditFormContent({
       5: 'cancelado'
     }
 
+    const _historialData: ArtistEntry['_historialData'] = {}
+
+    if (
+      historialChecks.pseudonimo &&
+      hasChanged.pseudonimo &&
+      artist.pseudonimo
+    ) {
+      _historialData.pseudonimo = artist.pseudonimo
+    }
+    if (historialChecks.correo && hasChanged.correo && artist.correo) {
+      _historialData.correo = artist.correo
+    }
+    if (historialChecks.rrss && hasChanged.rrss && artist.rrss) {
+      _historialData.rrss = artist.rrss
+    }
+    if (historialChecks.ciudad && hasChanged.ciudad && artist.ciudad) {
+      _historialData.ciudad = artist.ciudad
+    }
+    if (historialChecks.pais && hasChanged.pais && artist.pais) {
+      _historialData.pais = artist.pais
+    }
+
     update(artist.id, {
       nombre: formData.nombre,
       pseudonimo: formData.pseudonimo,
@@ -72,7 +116,8 @@ export function EditFormContent({
       ciudad: formData.city,
       pais: formData.country,
       estadoId: formData.statusId,
-      estadoSlug: estadoIdToSlug[formData.statusId] || 'desconocido'
+      estadoSlug: estadoIdToSlug[formData.statusId] || 'desconocido',
+      ...(Object.keys(_historialData).length > 0 && { _historialData })
     })
 
     onClose()
@@ -101,6 +146,26 @@ export function EditFormContent({
             placeholder='@usuario'
             required
           />
+          {hasChanged.pseudonimo && (
+            <div className='mt-1 flex items-center gap-2'>
+              <Switch
+                id='historial-pseudonimo'
+                checked={historialChecks.pseudonimo}
+                onCheckedChange={(checked) =>
+                  setHistorialChecks((prev) => ({
+                    ...prev,
+                    pseudonimo: checked
+                  }))
+                }
+              />
+              <Label
+                htmlFor='historial-pseudonimo'
+                className='text-muted-foreground cursor-pointer text-xs font-normal'
+              >
+                Guardar valor anterior en historial
+              </Label>
+            </div>
+          )}
         </Field>
 
         <div className='grid grid-cols-2 gap-4'>
@@ -113,6 +178,23 @@ export function EditFormContent({
               onChange={(e) => updateField('correo', e.target.value)}
               placeholder='artista@ejemplo.com'
             />
+            {hasChanged.correo && (
+              <div className='mt-1 flex items-center gap-2'>
+                <Switch
+                  id='historial-correo'
+                  checked={historialChecks.correo}
+                  onCheckedChange={(checked) =>
+                    setHistorialChecks((prev) => ({ ...prev, correo: checked }))
+                  }
+                />
+                <Label
+                  htmlFor='historial-correo'
+                  className='text-muted-foreground cursor-pointer text-xs font-normal'
+                >
+                  Guardar valor anterior en historial
+                </Label>
+              </div>
+            )}
           </Field>
           <Field>
             <FieldLabel htmlFor='estadoId'>Estado</FieldLabel>
@@ -153,6 +235,23 @@ export function EditFormContent({
               onChange={(e) => updateField('city', e.target.value)}
               placeholder='Santiago'
             />
+            {hasChanged.ciudad && (
+              <div className='mt-1 flex items-center gap-2'>
+                <Switch
+                  id='historial-ciudad'
+                  checked={historialChecks.ciudad}
+                  onCheckedChange={(checked) =>
+                    setHistorialChecks((prev) => ({ ...prev, ciudad: checked }))
+                  }
+                />
+                <Label
+                  htmlFor='historial-ciudad'
+                  className='text-muted-foreground cursor-pointer text-xs font-normal'
+                >
+                  Guardar valor anterior en historial
+                </Label>
+              </div>
+            )}
           </Field>
           <Field>
             <FieldLabel htmlFor='pais'>País</FieldLabel>
@@ -162,10 +261,44 @@ export function EditFormContent({
               onChange={(e) => updateField('country', e.target.value)}
               placeholder='Chile'
             />
+            {hasChanged.pais && (
+              <div className='mt-1 flex items-center gap-2'>
+                <Switch
+                  id='historial-pais'
+                  checked={historialChecks.pais}
+                  onCheckedChange={(checked) =>
+                    setHistorialChecks((prev) => ({ ...prev, pais: checked }))
+                  }
+                />
+                <Label
+                  htmlFor='historial-pais'
+                  className='text-muted-foreground cursor-pointer text-xs font-normal'
+                >
+                  Guardar valor anterior en historial
+                </Label>
+              </div>
+            )}
           </Field>
         </div>
 
         <ArtistRRSSManager initialValue={artist.rrss} onChange={updateRRSS} />
+        {hasChanged.rrss && (
+          <div className='mt-1 flex items-center gap-2'>
+            <Switch
+              id='historial-rrss'
+              checked={historialChecks.rrss}
+              onCheckedChange={(checked) =>
+                setHistorialChecks((prev) => ({ ...prev, rrss: checked }))
+              }
+            />
+            <Label
+              htmlFor='historial-rrss'
+              className='text-muted-foreground cursor-pointer text-xs font-normal'
+            >
+              Guardar valor anterior en historial
+            </Label>
+          </div>
+        )}
       </FieldGroup>
 
       <div className='flex justify-end gap-2 pt-4'>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
@@ -86,7 +86,11 @@ export const artistaHistorialInsertSchema = createInsertSchema(
   artistHistoryTable,
   {
     artistaId: () => z.coerce.number().int().positive(),
-    rrss: () => z.string().optional()
+    rrss: () =>
+      z.preprocess((val) => {
+        if (val && typeof val === 'object') return JSON.stringify(val)
+        return val
+      }, z.string().nullable().optional()) as z.ZodType<string | null | undefined>
   }
 )
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_schemas/artista.schema.ts
@@ -79,3 +79,17 @@ export const artistaImagenFormSchema = artistaImagenInsertSchema
 
 export type ArtistaFormInput = z.infer<typeof artistaFormSchema>
 export type ArtistaImagenFormInput = z.infer<typeof artistaImagenFormSchema>
+
+const artistHistoryTable = artistSchema.artistHistory
+
+export const artistaHistorialInsertSchema = createInsertSchema(
+  artistHistoryTable,
+  {
+    artistaId: () => z.coerce.number().int().positive(),
+    rrss: () => z.string().optional()
+  }
+)
+
+export type ArtistaHistorialInsertInput = z.infer<
+  typeof artistaHistorialInsertSchema
+>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_types/index.ts
@@ -6,6 +6,13 @@ export type ArtistEntry = Omit<RawArtist, 'id' | 'rrss'> & {
   id: string
   rrss: Record<string, string> | null
   estadoSlug?: string
+  _historialData?: Partial<{
+    pseudonimo: string
+    correo: string
+    rrss: Record<string, string>
+    ciudad: string
+    pais: string
+  }>
 }
 
 export interface ArtistListFilters {


### PR DESCRIPTION
## Summary

- Add per-field "archive to historial" Switch toggles in the artist edit dialog — when a tracked field's value changes, the user can toggle a switch to save the **old value** to the existing `artista_historial` table
- Historial INSERT is executed inside the existing server action transaction (same atomicity as the artist update)
- Cache invalidation for `ARTISTA_HISTORIAL_CACHE_TAG` ensures the read-only history dialog reflects new entries immediately

## Details

### Tracked fields (5)
`pseudonimo`, `correo`, `rrss`, `ciudad`, `pais` — matches the existing `artista_historial` table columns.

### How it works
1. User opens the edit dialog for an existing artist
2. When a tracked field's value is changed **and** the original value is non-empty, a Switch toggle appears inline below the input: *"Guardar valor anterior en historial"*
3. On save, the **old values** of toggled fields ride as `_historialData` inside the update operation payload
4. The server action extracts `_historialData` before Zod validation (to prevent stripping), then INSERTs into `artista_historial` within the same DB transaction
5. `orden` is safely computed as `COALESCE(MAX(orden), 0) + 1` per artist

### Edge cases handled
- `rrss` uses `JSON.stringify` deep comparison (avoids reference equality false-positive)
- Field name mapping: `formData.city` → DB `ciudad`, `formData.country` → DB `pais`
- Empty/null old values: no Switch shown, nothing archived
- First-ever history entry: `COALESCE` prevents NULL orden

### No changes to
- Database schema or migrations (`artista_historial` already exists)
- Journal/push pipeline infrastructure
- Existing read-only history dialog (auto-refreshes via cache tag)

## Files changed (4)

| File | Change |
|---|---|
| `_types/index.ts` | Added `_historialData?` optional field to `ArtistEntry` |
| `_schemas/artista.schema.ts` | Added `artistaHistorialInsertSchema` + `ArtistaHistorialInsertInput` |
| `_components/edit-artist-dialog.tsx` | Added `historialChecks` state, `hasChanged` logic, 5 Switch toggles, `_historialData` builder in `handleSave` |
| `_actions/save-artista.action.ts` | Extract `_historialData` before Zod, INSERT into `artista_historial` in tx, invalidate historial cache tag |

## Verification

- `bun run type-check` ✅
- `bun run lint` ✅ (0 errors, 4 pre-existing warnings)
- `bun run build` ✅
- Manual QA ✅ (Switch appears/disappears reactively, save creates DB row, history dialog shows entry)