### PR TITLE
feat(dashboard): add bento-grid stats with shared cache tags

### DIFF
--- a/apps/admin/package.json
+++ b/apps/admin/package.json
@@ -43,6 +43,7 @@
     "react": "^19.2.4",
     "react-day-picker": "^9.14.0",
     "react-dom": "^19.2.4",
+    "recharts": "2.15.4",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.4.0",
     "use-debounce": "^10.1.0",

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-content.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-content.tsx
@@ -1,21 +1,70 @@
+import { Suspense } from 'react'
 import {
   Card,
   CardHeader,
   CardTitle,
   CardContent
 } from '@/shared/components/ui/card'
+import { Skeleton } from '@/shared/components/ui/skeleton'
+import {
+  getDashboardArtistStats,
+  getDashboardEventStats,
+  getDashboardGrowthData,
+  getDashboardDisciplineData,
+  getDashboardTopArtists,
+  getDashboardGeographicData
+} from '../_lib/get-dashboard-stats'
+import { DISCIPLINE_LABELS } from '../_constants'
 import {
   DashboardSessionExpiration,
   DashboardUserEmail,
   DashboardUserName,
   DashboardWelcomeName
 } from './dashboard-user-info'
-import { Suspense } from 'react'
-import { Skeleton } from '@/shared/components/ui/skeleton'
+import { DashboardKpiCards } from './dashboard-kpi-cards'
+import { FestivalGrowthChart } from './festival-growth-chart'
+import { DashboardDataHealth } from './dashboard-data-health'
+import { DisciplineDonutChart } from './discipline-donut-chart'
+import { DashboardGeography } from './dashboard-geography'
+import { DashboardTopArtists } from './dashboard-top-artists'
 
-export function DashboardContent() {
+export async function DashboardContent() {
+  const [
+    artistResult,
+    eventResult,
+    growthResult,
+    disciplineResult,
+    topArtistsResult,
+    geoResult
+  ] = await Promise.allSettled([
+    getDashboardArtistStats(),
+    getDashboardEventStats(),
+    getDashboardGrowthData(),
+    getDashboardDisciplineData(),
+    getDashboardTopArtists(),
+    getDashboardGeographicData()
+  ])
+
+  const artistStats =
+    artistResult.status === 'fulfilled' ? artistResult.value : null
+  const eventStats =
+    eventResult.status === 'fulfilled' ? eventResult.value : null
+  const growthData =
+    growthResult.status === 'fulfilled' ? (growthResult.value ?? []) : []
+  const disciplineData =
+    disciplineResult.status === 'fulfilled'
+      ? (disciplineResult.value ?? [])
+      : []
+  const topArtists =
+    topArtistsResult.status === 'fulfilled'
+      ? (topArtistsResult.value ?? [])
+      : []
+  const geoData =
+    geoResult.status === 'fulfilled' ? (geoResult.value ?? []) : []
+
   return (
     <>
+      {/* Header — PRESERVED */}
       <header>
         <h1 className='text-foreground text-2xl font-bold'>Dashboard</h1>
 
@@ -32,6 +81,7 @@ export function DashboardContent() {
         </p>
       </header>
 
+      {/* Session card — PRESERVED */}
       <section className='flex flex-wrap gap-4'>
         <Card className='w-full max-w-md'>
           <CardHeader>
@@ -58,6 +108,39 @@ export function DashboardContent() {
             </div>
           </CardContent>
         </Card>
+      </section>
+
+      {/* Row 1: Hero KPI cards */}
+      <section>
+        <DashboardKpiCards artistStats={artistStats} eventStats={eventStats} />
+      </section>
+
+      {/* Row 2: Growth chart (3/4) + Data health (1/4) */}
+      <section className='grid grid-cols-1 gap-4 lg:grid-cols-4'>
+        <div className='lg:col-span-3'>
+          <FestivalGrowthChart data={growthData} />
+        </div>
+        <div className='lg:col-span-1'>
+          <DashboardDataHealth
+            completeness={artistStats?.completeness ?? null}
+          />
+        </div>
+      </section>
+
+      {/* Row 3: Discipline donut (1/4) + Geography (1/4) + Top artists (2/4) */}
+      <section className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-4'>
+        <div className='lg:col-span-1'>
+          <DisciplineDonutChart
+            data={disciplineData}
+            labels={DISCIPLINE_LABELS}
+          />
+        </div>
+        <div className='lg:col-span-1'>
+          <DashboardGeography data={geoData} />
+        </div>
+        <div className='lg:col-span-2'>
+          <DashboardTopArtists artists={topArtists} />
+        </div>
       </section>
     </>
   )

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-data-health.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-data-health.tsx
@@ -1,0 +1,60 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import { Progress } from '@/shared/components/ui/progress'
+import type { DataCompleteness } from '../_types'
+
+type Props = {
+  completeness: DataCompleteness | null
+}
+
+function pct(part: number, total: number): number {
+  if (total === 0) return 0
+  return Math.round((part / total) * 100)
+}
+
+export function DashboardDataHealth({ completeness }: Props) {
+  if (!completeness) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Salud de la Base de Datos</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-sm'>Sin datos disponibles</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const rows = [
+    { label: 'Correo', value: pct(completeness.withEmail, completeness.total) },
+    {
+      label: 'Teléfono',
+      value: pct(completeness.withPhone, completeness.total)
+    },
+    { label: 'RUT', value: pct(completeness.withRut, completeness.total) }
+  ]
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Salud de la Base de Datos</CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-4'>
+        {rows.map((row) => (
+          <div key={row.label} className='space-y-1'>
+            <div className='flex items-center justify-between text-sm'>
+              <span>{row.label}</span>
+              <span className='text-muted-foreground'>{row.value}%</span>
+            </div>
+            <Progress value={row.value} className='h-2' />
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-geography.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-geography.tsx
@@ -1,0 +1,58 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import type { CityPoint } from '../_types'
+
+type Props = {
+  data: CityPoint[]
+}
+
+export function DashboardGeography({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Origen Geográfico</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-sm'>
+            Sin datos de ubicación
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const maxCount = Math.max(...data.map((d) => d.count))
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Origen Geográfico</CardTitle>
+      </CardHeader>
+      <CardContent className='space-y-3'>
+        {data.map((city) => {
+          const widthPct = maxCount > 0 ? (city.count / maxCount) * 100 : 0
+
+          return (
+            <div key={city.ciudad} className='space-y-1'>
+              <div className='flex items-center justify-between text-sm'>
+                <span>{city.ciudad}</span>
+                <span className='text-muted-foreground'>{city.count}</span>
+              </div>
+              <div className='bg-secondary h-2 w-full overflow-hidden rounded-full'>
+                <div
+                  className='bg-primary h-full rounded-full transition-all'
+                  style={{ width: `${widthPct}%` }}
+                />
+              </div>
+            </div>
+          )
+        })}
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-kpi-cards.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-kpi-cards.tsx
@@ -1,0 +1,93 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import { Users, Ticket, BookOpen, CalendarDays } from 'lucide-react'
+import type { DashboardArtistStats, DashboardEventStats } from '../_types'
+
+type Props = {
+  artistStats: DashboardArtistStats | null
+  eventStats: DashboardEventStats | null
+}
+
+export function DashboardKpiCards({ artistStats, eventStats }: Props) {
+  const activeCount =
+    artistStats?.byStatus.find((s) => s.slug === 'activo')?.count ?? 0
+  const inactiveCount =
+    artistStats?.byStatus.find((s) => s.slug === 'inactivo')?.count ?? 0
+  const latestEdition = eventStats?.latestEdition
+
+  return (
+    <div className='grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4'>
+      <Card>
+        <CardHeader className='flex flex-row items-center justify-between pb-2'>
+          <CardTitle className='text-muted-foreground text-sm font-medium'>
+            Total de Artistas
+          </CardTitle>
+          <Users className='text-muted-foreground h-4 w-4' />
+        </CardHeader>
+        <CardContent>
+          <p className='text-2xl font-bold'>{artistStats?.total ?? '—'}</p>
+          <p className='text-muted-foreground text-xs'>
+            {activeCount} activos · {inactiveCount} inactivos
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className='flex flex-row items-center justify-between pb-2'>
+          <CardTitle className='text-muted-foreground text-sm font-medium'>
+            Participaciones Históricas
+          </CardTitle>
+          <Ticket className='text-muted-foreground h-4 w-4' />
+        </CardHeader>
+        <CardContent>
+          <p className='text-2xl font-bold'>
+            {eventStats?.totalParticipations ?? '—'}
+          </p>
+          <p className='text-muted-foreground text-xs'>
+            En {eventStats?.totalEditions ?? '—'} ediciones
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className='flex flex-row items-center justify-between pb-2'>
+          <CardTitle className='text-muted-foreground text-sm font-medium'>
+            Catálogo Activo
+          </CardTitle>
+          <BookOpen className='text-muted-foreground h-4 w-4' />
+        </CardHeader>
+        <CardContent>
+          <p className='text-2xl font-bold'>
+            {artistStats?.catalogActive ?? '—'}
+          </p>
+          <p className='text-muted-foreground text-xs'>
+            Artistas en catálogo público
+          </p>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className='flex flex-row items-center justify-between pb-2'>
+          <CardTitle className='text-muted-foreground text-sm font-medium'>
+            Última Edición
+          </CardTitle>
+          <CalendarDays className='text-muted-foreground h-4 w-4' />
+        </CardHeader>
+        <CardContent>
+          <p className='text-2xl font-bold'>
+            {latestEdition ? `Festival ${latestEdition.numeroEdicion}` : '—'}
+          </p>
+          <p className='text-muted-foreground text-xs'>
+            {latestEdition
+              ? `${latestEdition.participantCount} participantes`
+              : 'Sin datos'}
+          </p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-top-artists.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/dashboard-top-artists.tsx
@@ -1,0 +1,51 @@
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import type { TopArtistEntry } from '../_types'
+
+type Props = {
+  artists: TopArtistEntry[]
+}
+
+export function DashboardTopArtists({ artists }: Props) {
+  if (artists.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Artistas Frecuentes</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-sm'>
+            Sin participaciones registradas
+          </p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Artistas Frecuentes</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ol className='space-y-2'>
+          {artists.map((artist, index) => (
+            <li key={artist.id} className='flex items-center gap-3 text-sm'>
+              <span className='text-muted-foreground w-5 text-right font-medium'>
+                {index + 1}
+              </span>
+              <span className='flex-1 truncate'>{artist.pseudonimo}</span>
+              <span className='text-muted-foreground text-xs'>
+                {artist.ediciones} ediciones
+              </span>
+            </li>
+          ))}
+        </ol>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/discipline-donut-chart.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/discipline-donut-chart.tsx
@@ -1,0 +1,97 @@
+'use client'
+
+import { Pie, PieChart, Cell } from 'recharts'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent
+} from '@/shared/components/ui/chart'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import type { DisciplinePoint } from '../_types'
+import type { ChartConfig } from '@/shared/components/ui/chart'
+
+type Props = {
+  data: DisciplinePoint[]
+  labels: Record<string, string>
+}
+
+const CHART_COLORS = [
+  'var(--color-chart-1)',
+  'var(--color-chart-2)',
+  'var(--color-chart-3)',
+  'var(--color-chart-4)',
+  'var(--color-chart-5)'
+]
+
+function buildChartConfig(
+  data: DisciplinePoint[],
+  labels: Record<string, string>
+): ChartConfig {
+  const config: ChartConfig = {}
+  for (const [index, point] of data.entries()) {
+    config[point.disciplina] = {
+      label: labels[point.disciplina] ?? point.disciplina,
+      color: CHART_COLORS[index % CHART_COLORS.length]
+    }
+  }
+  return config
+}
+
+export function DisciplineDonutChart({ data, labels }: Props) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Disciplinas</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-sm'>Sin datos disponibles</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  const chartConfig = buildChartConfig(data, labels)
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Disciplinas</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='mx-auto h-[250px]'>
+          <PieChart accessibilityLayer>
+            <ChartTooltip
+              content={<ChartTooltipContent nameKey='disciplina' />}
+            />
+            <Pie
+              data={data}
+              dataKey='count'
+              nameKey='disciplina'
+              innerRadius={60}
+              outerRadius={90}
+              strokeWidth={2}
+            >
+              {data.map((entry, index) => (
+                <Cell
+                  key={entry.disciplina}
+                  fill={CHART_COLORS[index % CHART_COLORS.length]}
+                />
+              ))}
+            </Pie>
+            <ChartLegend
+              content={<ChartLegendContent nameKey='disciplina' />}
+            />
+          </PieChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/festival-growth-chart.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_components/festival-growth-chart.tsx
@@ -1,0 +1,79 @@
+'use client'
+
+import { Area, AreaChart, CartesianGrid, XAxis, YAxis } from 'recharts'
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent
+} from '@/shared/components/ui/chart'
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle
+} from '@/shared/components/ui/card'
+import type { EditionGrowthPoint } from '../_types'
+import type { ChartConfig } from '@/shared/components/ui/chart'
+
+type Props = {
+  data: EditionGrowthPoint[]
+}
+
+const chartConfig = {
+  participantes: {
+    label: 'Participantes',
+    color: 'var(--color-chart-1)'
+  }
+} satisfies ChartConfig
+
+export function FestivalGrowthChart({ data }: Props) {
+  if (data.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Crecimiento del Festival</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className='text-muted-foreground text-sm'>Sin datos disponibles</p>
+        </CardContent>
+      </Card>
+    )
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Crecimiento del Festival</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer config={chartConfig} className='h-[250px] w-full'>
+          <AreaChart data={data} accessibilityLayer>
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey='numero'
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+            />
+            <YAxis tickLine={false} axisLine={false} tickMargin={8} />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(value) => `Edición ${value}`}
+                />
+              }
+            />
+            <Area
+              dataKey='participantes'
+              type='monotone'
+              fill='var(--color-participantes)'
+              fillOpacity={0.3}
+              stroke='var(--color-participantes)'
+              strokeWidth={2}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_constants/index.ts
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_constants/index.ts
@@ -1,0 +1,11 @@
+// Festival event ID (Festival Frijol Mágico — id=1 in DB)
+export const FESTIVAL_EVENT_ID = 1
+
+// Human-readable labels for the 4 discipline slugs
+// (discipline table only stores slug, no display name column)
+export const DISCIPLINE_LABELS: Record<string, string> = {
+  ilustracion: 'Ilustración',
+  'narrativa-grafica': 'Narrativa Gráfica',
+  manualidades: 'Manualidades',
+  fotografia: 'Fotografía'
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_lib/get-dashboard-stats.ts
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_lib/get-dashboard-stats.ts
@@ -1,0 +1,227 @@
+'use server'
+
+import { cacheTag } from 'next/cache'
+import { count, desc, asc, eq, and, isNotNull, sql } from 'drizzle-orm'
+
+import { db } from '@frijolmagico/database/orm'
+import {
+  artist,
+  events,
+  core,
+  participations
+} from '@frijolmagico/database/schema'
+import { isNotDeleted } from '@frijolmagico/database/filters'
+
+import { ARTISTA_CACHE_TAG } from '@/admin/artistas/_constants'
+import { CATALOG_CACHE_TAG } from '@/admin/artistas/catalogo/_constants'
+import {
+  EVENTO_CACHE_TAG,
+  EVENTO_EDICION_CACHE_TAG
+} from '@/admin/eventos/_constants'
+
+import type {
+  DashboardArtistStats,
+  DashboardEventStats,
+  EditionGrowthPoint,
+  DisciplinePoint,
+  CityPoint,
+  TopArtistEntry
+} from '../_types'
+import { FESTIVAL_EVENT_ID } from '../_constants'
+
+const { artist: artistTable, artistStatus, catalogArtist } = artist
+const { eventEdition } = events
+const { discipline } = core
+const { eventEditionParticipant, participantExhibition } = participations
+
+export async function getDashboardArtistStats(): Promise<DashboardArtistStats | null> {
+  'use cache'
+  cacheTag(ARTISTA_CACHE_TAG, CATALOG_CACHE_TAG)
+
+  const [statusRows, catalogRow, completenessRow] = await Promise.all([
+    db
+      .select({ slug: artistStatus.slug, count: count() })
+      .from(artistTable)
+      .leftJoin(artistStatus, eq(artistTable.estadoId, artistStatus.id))
+      .where(isNotDeleted(artistTable.deletedAt))
+      .groupBy(artistStatus.slug),
+    db
+      .select({ count: count() })
+      .from(catalogArtist)
+      .where(
+        and(
+          eq(catalogArtist.activo, true),
+          isNotDeleted(catalogArtist.deletedAt)
+        )
+      ),
+    db
+      .select({
+        total: count(),
+        withEmail: sql<number>`COUNT(CASE WHEN ${artistTable.correo} IS NOT NULL THEN 1 END)`,
+        withPhone: sql<number>`COUNT(CASE WHEN ${artistTable.telefono} IS NOT NULL THEN 1 END)`,
+        withRut: sql<number>`COUNT(CASE WHEN ${artistTable.rut} IS NOT NULL THEN 1 END)`
+      })
+      .from(artistTable)
+      .where(isNotDeleted(artistTable.deletedAt))
+  ])
+
+  if (!completenessRow[0]) return null
+
+  return {
+    total: statusRows.reduce((sum, r) => sum + r.count, 0),
+    byStatus: statusRows.map((r) => ({
+      slug: r.slug ?? 'desconocido',
+      count: r.count
+    })),
+    catalogActive: catalogRow[0]?.count ?? 0,
+    completeness: {
+      total: completenessRow[0].total,
+      withEmail: completenessRow[0].withEmail,
+      withPhone: completenessRow[0].withPhone,
+      withRut: completenessRow[0].withRut
+    }
+  }
+}
+
+export async function getDashboardEventStats(): Promise<DashboardEventStats | null> {
+  'use cache'
+  cacheTag(EVENTO_CACHE_TAG, EVENTO_EDICION_CACHE_TAG)
+
+  const [participationRow, editionCountRow, latestRows] = await Promise.all([
+    db.select({ count: count() }).from(eventEditionParticipant),
+    db.select({ count: count() }).from(eventEdition),
+    db
+      .select({
+        id: eventEdition.id,
+        nombre: eventEdition.nombre,
+        numeroEdicion: eventEdition.numeroEdicion,
+        participantCount: count(eventEditionParticipant.id)
+      })
+      .from(eventEdition)
+      .leftJoin(
+        eventEditionParticipant,
+        eq(eventEdition.id, eventEditionParticipant.eventoEdicionId)
+      )
+      .where(eq(eventEdition.eventoId, FESTIVAL_EVENT_ID))
+      .groupBy(eventEdition.id)
+      .orderBy(desc(eventEdition.id))
+      .limit(1)
+  ])
+
+  const latest = latestRows[0] ?? null
+
+  return {
+    totalParticipations: participationRow[0]?.count ?? 0,
+    totalEditions: editionCountRow[0]?.count ?? 0,
+    latestEdition: latest
+      ? {
+          id: String(latest.id),
+          nombre: latest.nombre || null,
+          numeroEdicion: latest.numeroEdicion,
+          participantCount: latest.participantCount
+        }
+      : null
+  }
+}
+
+export async function getDashboardGrowthData(): Promise<EditionGrowthPoint[]> {
+  'use cache'
+  cacheTag(ARTISTA_CACHE_TAG, EVENTO_EDICION_CACHE_TAG)
+
+  const rows = await db
+    .select({
+      edicionId: eventEdition.id,
+      numero: eventEdition.numeroEdicion,
+      nombre: eventEdition.nombre,
+      participantes: count(eventEditionParticipant.id)
+    })
+    .from(eventEdition)
+    .leftJoin(
+      eventEditionParticipant,
+      eq(eventEdition.id, eventEditionParticipant.eventoEdicionId)
+    )
+    .where(eq(eventEdition.eventoId, FESTIVAL_EVENT_ID))
+    .groupBy(eventEdition.id)
+    .orderBy(asc(eventEdition.id))
+
+  return rows.map((r) => ({
+    edicionId: String(r.edicionId),
+    numero: r.numero,
+    nombre: r.nombre || null,
+    participantes: r.participantes
+  }))
+}
+
+export async function getDashboardDisciplineData(): Promise<DisciplinePoint[]> {
+  'use cache'
+  cacheTag(ARTISTA_CACHE_TAG, EVENTO_EDICION_CACHE_TAG)
+
+  const rows = await db
+    .select({
+      disciplina: discipline.slug,
+      count: count()
+    })
+    .from(participantExhibition)
+    .innerJoin(
+      discipline,
+      eq(participantExhibition.disciplinaId, discipline.id)
+    )
+    .groupBy(discipline.slug)
+    .orderBy(desc(count()))
+
+  return rows.map((r) => ({
+    disciplina: r.disciplina,
+    count: r.count
+  }))
+}
+
+export async function getDashboardTopArtists(): Promise<TopArtistEntry[]> {
+  'use cache'
+  cacheTag(ARTISTA_CACHE_TAG, EVENTO_EDICION_CACHE_TAG)
+
+  const rows = await db
+    .select({
+      id: artistTable.id,
+      pseudonimo: artistTable.pseudonimo,
+      ediciones: count(eventEditionParticipant.id)
+    })
+    .from(eventEditionParticipant)
+    .innerJoin(
+      artistTable,
+      eq(eventEditionParticipant.artistaId, artistTable.id)
+    )
+    .groupBy(artistTable.id)
+    .orderBy(desc(count(eventEditionParticipant.id)))
+    .limit(5)
+
+  return rows.map((r) => ({
+    id: String(r.id),
+    pseudonimo: r.pseudonimo,
+    ediciones: r.ediciones
+  }))
+}
+
+export async function getDashboardGeographicData(): Promise<CityPoint[]> {
+  'use cache'
+  cacheTag(ARTISTA_CACHE_TAG)
+
+  const rows = await db
+    .select({
+      ciudad: artistTable.ciudad,
+      count: count()
+    })
+    .from(artistTable)
+    .where(
+      and(isNotDeleted(artistTable.deletedAt), isNotNull(artistTable.ciudad))
+    )
+    .groupBy(artistTable.ciudad)
+    .orderBy(desc(count()))
+    .limit(6)
+
+  return rows
+    .filter((r): r is typeof r & { ciudad: string } => r.ciudad !== null)
+    .map((r) => ({
+      ciudad: r.ciudad,
+      count: r.count
+    }))
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_types/index.ts
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/_types/index.ts
@@ -1,0 +1,52 @@
+export type ArtistStatusStat = {
+  slug: string
+  count: number
+}
+
+export type DataCompleteness = {
+  total: number
+  withEmail: number
+  withPhone: number
+  withRut: number
+}
+
+export type DashboardArtistStats = {
+  total: number
+  byStatus: ArtistStatusStat[]
+  catalogActive: number
+  completeness: DataCompleteness
+}
+
+export type DashboardEventStats = {
+  totalParticipations: number
+  totalEditions: number
+  latestEdition: {
+    id: string
+    nombre: string | null
+    numeroEdicion: string
+    participantCount: number
+  } | null
+}
+
+export type EditionGrowthPoint = {
+  edicionId: string
+  numero: string
+  nombre: string | null
+  participantes: number
+}
+
+export type DisciplinePoint = {
+  disciplina: string
+  count: number
+}
+
+export type CityPoint = {
+  ciudad: string
+  count: number
+}
+
+export type TopArtistEntry = {
+  id: string
+  pseudonimo: string
+  ediciones: number
+}

--- a/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/page.tsx
+++ b/apps/admin/src/app/(authenticated)/(dashboard)/dashboard/page.tsx
@@ -1,9 +1,29 @@
+import { Suspense } from 'react'
+import { Skeleton } from '@/shared/components/ui/skeleton'
 import { DashboardContent } from './_components/dashboard-content'
+
+function DashboardSkeleton() {
+  return (
+    <div className='space-y-6'>
+      <div>
+        <Skeleton className='h-8 w-32' />
+        <Skeleton className='mt-2 h-4 w-64' />
+      </div>
+      <div className='grid grid-cols-4 gap-4'>
+        {Array.from({ length: 4 }).map((_, i) => (
+          <Skeleton key={i} className='h-28 w-full rounded-xl' />
+        ))}
+      </div>
+    </div>
+  )
+}
 
 export default function DashboardPage() {
   return (
     <article className='space-y-6'>
-      <DashboardContent />
+      <Suspense fallback={<DashboardSkeleton />}>
+        <DashboardContent />
+      </Suspense>
     </article>
   )
 }

--- a/apps/admin/src/shared/components/ui/chart.tsx
+++ b/apps/admin/src/shared/components/ui/chart.tsx
@@ -1,0 +1,356 @@
+"use client"
+
+import * as React from "react"
+import * as RechartsPrimitive from "recharts"
+
+import { cn } from "@/lib/utils"
+
+// Format: { THEME_NAME: CSS_SELECTOR }
+const THEMES = { light: "", dark: ".dark" } as const
+
+export type ChartConfig = {
+  [k in string]: {
+    label?: React.ReactNode
+    icon?: React.ComponentType
+  } & (
+    | { color?: string; theme?: never }
+    | { color?: never; theme: Record<keyof typeof THEMES, string> }
+  )
+}
+
+type ChartContextProps = {
+  config: ChartConfig
+}
+
+const ChartContext = React.createContext<ChartContextProps | null>(null)
+
+function useChart() {
+  const context = React.useContext(ChartContext)
+
+  if (!context) {
+    throw new Error("useChart must be used within a <ChartContainer />")
+  }
+
+  return context
+}
+
+function ChartContainer({
+  id,
+  className,
+  children,
+  config,
+  ...props
+}: React.ComponentProps<"div"> & {
+  config: ChartConfig
+  children: React.ComponentProps<
+    typeof RechartsPrimitive.ResponsiveContainer
+  >["children"]
+}) {
+  const uniqueId = React.useId()
+  const chartId = `chart-${id || uniqueId.replace(/:/g, "")}`
+
+  return (
+    <ChartContext.Provider value={{ config }}>
+      <div
+        data-slot="chart"
+        data-chart={chartId}
+        className={cn(
+          "flex aspect-video justify-center text-xs [&_.recharts-cartesian-axis-tick_text]:fill-muted-foreground [&_.recharts-cartesian-grid_line[stroke='#ccc']]:stroke-border/50 [&_.recharts-curve.recharts-tooltip-cursor]:stroke-border [&_.recharts-dot[stroke='#fff']]:stroke-transparent [&_.recharts-layer]:outline-hidden [&_.recharts-polar-grid_[stroke='#ccc']]:stroke-border [&_.recharts-radial-bar-background-sector]:fill-muted [&_.recharts-rectangle.recharts-tooltip-cursor]:fill-muted [&_.recharts-reference-line_[stroke='#ccc']]:stroke-border [&_.recharts-sector]:outline-hidden [&_.recharts-sector[stroke='#fff']]:stroke-transparent [&_.recharts-surface]:outline-hidden",
+          className
+        )}
+        {...props}
+      >
+        <ChartStyle id={chartId} config={config} />
+        <RechartsPrimitive.ResponsiveContainer>
+          {children}
+        </RechartsPrimitive.ResponsiveContainer>
+      </div>
+    </ChartContext.Provider>
+  )
+}
+
+const ChartStyle = ({ id, config }: { id: string; config: ChartConfig }) => {
+  const colorConfig = Object.entries(config).filter(
+    ([, config]) => config.theme || config.color
+  )
+
+  if (!colorConfig.length) {
+    return null
+  }
+
+  return (
+    <style
+      dangerouslySetInnerHTML={{
+        __html: Object.entries(THEMES)
+          .map(
+            ([theme, prefix]) => `
+${prefix} [data-chart=${id}] {
+${colorConfig
+  .map(([key, itemConfig]) => {
+    const color =
+      itemConfig.theme?.[theme as keyof typeof itemConfig.theme] ||
+      itemConfig.color
+    return color ? `  --color-${key}: ${color};` : null
+  })
+  .join("\n")}
+}
+`
+          )
+          .join("\n"),
+      }}
+    />
+  )
+}
+
+const ChartTooltip = RechartsPrimitive.Tooltip
+
+function ChartTooltipContent({
+  active,
+  payload,
+  className,
+  indicator = "dot",
+  hideLabel = false,
+  hideIndicator = false,
+  label,
+  labelFormatter,
+  labelClassName,
+  formatter,
+  color,
+  nameKey,
+  labelKey,
+}: React.ComponentProps<typeof RechartsPrimitive.Tooltip> &
+  React.ComponentProps<"div"> & {
+    hideLabel?: boolean
+    hideIndicator?: boolean
+    indicator?: "line" | "dot" | "dashed"
+    nameKey?: string
+    labelKey?: string
+  }) {
+  const { config } = useChart()
+
+  const tooltipLabel = React.useMemo(() => {
+    if (hideLabel || !payload?.length) {
+      return null
+    }
+
+    const [item] = payload
+    const key = `${labelKey || item?.dataKey || item?.name || "value"}`
+    const itemConfig = getPayloadConfigFromPayload(config, item, key)
+    const value =
+      !labelKey && typeof label === "string"
+        ? config[label as keyof typeof config]?.label || label
+        : itemConfig?.label
+
+    if (labelFormatter) {
+      return (
+        <div className={cn("font-medium", labelClassName)}>
+          {labelFormatter(value, payload)}
+        </div>
+      )
+    }
+
+    if (!value) {
+      return null
+    }
+
+    return <div className={cn("font-medium", labelClassName)}>{value}</div>
+  }, [
+    label,
+    labelFormatter,
+    payload,
+    hideLabel,
+    labelClassName,
+    config,
+    labelKey,
+  ])
+
+  if (!active || !payload?.length) {
+    return null
+  }
+
+  const nestLabel = payload.length === 1 && indicator !== "dot"
+
+  return (
+    <div
+      className={cn(
+        "grid min-w-32 items-start gap-1.5 rounded-lg border border-border/50 bg-background px-2.5 py-1.5 text-xs shadow-xl",
+        className
+      )}
+    >
+      {!nestLabel ? tooltipLabel : null}
+      <div className="grid gap-1.5">
+        {payload
+          .filter((item) => item.type !== "none")
+          .map((item, index) => {
+            const key = `${nameKey || item.name || item.dataKey || "value"}`
+            const itemConfig = getPayloadConfigFromPayload(config, item, key)
+            const indicatorColor = color || item.payload.fill || item.color
+
+            return (
+              <div
+                key={item.dataKey}
+                className={cn(
+                  "flex w-full flex-wrap items-stretch gap-2 [&>svg]:h-2.5 [&>svg]:w-2.5 [&>svg]:text-muted-foreground",
+                  indicator === "dot" && "items-center"
+                )}
+              >
+                {formatter && item?.value !== undefined && item.name ? (
+                  formatter(item.value, item.name, item, index, item.payload)
+                ) : (
+                  <>
+                    {itemConfig?.icon ? (
+                      <itemConfig.icon />
+                    ) : (
+                      !hideIndicator && (
+                        <div
+                          className={cn(
+                            "shrink-0 rounded-[2px] border-(--color-border) bg-(--color-bg)",
+                            {
+                              "h-2.5 w-2.5": indicator === "dot",
+                              "w-1": indicator === "line",
+                              "w-0 border-[1.5px] border-dashed bg-transparent":
+                                indicator === "dashed",
+                              "my-0.5": nestLabel && indicator === "dashed",
+                            }
+                          )}
+                          style={
+                            {
+                              "--color-bg": indicatorColor,
+                              "--color-border": indicatorColor,
+                            } as React.CSSProperties
+                          }
+                        />
+                      )
+                    )}
+                    <div
+                      className={cn(
+                        "flex flex-1 justify-between leading-none",
+                        nestLabel ? "items-end" : "items-center"
+                      )}
+                    >
+                      <div className="grid gap-1.5">
+                        {nestLabel ? tooltipLabel : null}
+                        <span className="text-muted-foreground">
+                          {itemConfig?.label || item.name}
+                        </span>
+                      </div>
+                      {item.value && (
+                        <span className="font-mono font-medium text-foreground tabular-nums">
+                          {item.value.toLocaleString()}
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
+              </div>
+            )
+          })}
+      </div>
+    </div>
+  )
+}
+
+const ChartLegend = RechartsPrimitive.Legend
+
+function ChartLegendContent({
+  className,
+  hideIcon = false,
+  payload,
+  verticalAlign = "bottom",
+  nameKey,
+}: React.ComponentProps<"div"> &
+  Pick<RechartsPrimitive.LegendProps, "payload" | "verticalAlign"> & {
+    hideIcon?: boolean
+    nameKey?: string
+  }) {
+  const { config } = useChart()
+
+  if (!payload?.length) {
+    return null
+  }
+
+  return (
+    <div
+      className={cn(
+        "flex items-center justify-center gap-4",
+        verticalAlign === "top" ? "pb-3" : "pt-3",
+        className
+      )}
+    >
+      {payload
+        .filter((item) => item.type !== "none")
+        .map((item) => {
+          const key = `${nameKey || item.dataKey || "value"}`
+          const itemConfig = getPayloadConfigFromPayload(config, item, key)
+
+          return (
+            <div
+              key={item.value}
+              className={cn(
+                "flex items-center gap-1.5 [&>svg]:h-3 [&>svg]:w-3 [&>svg]:text-muted-foreground"
+              )}
+            >
+              {itemConfig?.icon && !hideIcon ? (
+                <itemConfig.icon />
+              ) : (
+                <div
+                  className="h-2 w-2 shrink-0 rounded-[2px]"
+                  style={{
+                    backgroundColor: item.color,
+                  }}
+                />
+              )}
+              {itemConfig?.label}
+            </div>
+          )
+        })}
+    </div>
+  )
+}
+
+function getPayloadConfigFromPayload(
+  config: ChartConfig,
+  payload: unknown,
+  key: string
+) {
+  if (typeof payload !== "object" || payload === null) {
+    return undefined
+  }
+
+  const payloadPayload =
+    "payload" in payload &&
+    typeof payload.payload === "object" &&
+    payload.payload !== null
+      ? payload.payload
+      : undefined
+
+  let configLabelKey: string = key
+
+  if (
+    key in payload &&
+    typeof payload[key as keyof typeof payload] === "string"
+  ) {
+    configLabelKey = payload[key as keyof typeof payload] as string
+  } else if (
+    payloadPayload &&
+    key in payloadPayload &&
+    typeof payloadPayload[key as keyof typeof payloadPayload] === "string"
+  ) {
+    configLabelKey = payloadPayload[
+      key as keyof typeof payloadPayload
+    ] as string
+  }
+
+  return configLabelKey in config
+    ? config[configLabelKey]
+    : config[key as keyof typeof config]
+}
+
+export {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  ChartLegend,
+  ChartLegendContent,
+  ChartStyle,
+}

--- a/apps/admin/src/styles/globals.css
+++ b/apps/admin/src/styles/globals.css
@@ -71,9 +71,9 @@
   --border: oklch(0.922 0 0);
   --input: oklch(0.922 0 0);
   --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
+  --chart-1: oklch(0.65 0.15 140);
+  --chart-2: oklch(0.7 0.12 30);
+  --chart-3: oklch(0.6 0.1 250);
   --chart-4: oklch(0.828 0.189 84.429);
   --chart-5: oklch(0.769 0.188 70.08);
   --sidebar: oklch(0.985 0 0);

--- a/bun.lock
+++ b/bun.lock
@@ -44,6 +44,7 @@
         "react": "^19.2.4",
         "react-day-picker": "^9.14.0",
         "react-dom": "^19.2.4",
+        "recharts": "2.15.4",
         "sonner": "^2.0.7",
         "tailwind-merge": "^3.4.0",
         "use-debounce": "^10.1.0",
@@ -669,6 +670,24 @@
 
     "@types/bun": ["@types/bun@1.3.9", "", { "dependencies": { "bun-types": "1.3.9" } }, "sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw=="],
 
+    "@types/d3-array": ["@types/d3-array@3.2.2", "", {}, "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw=="],
+
+    "@types/d3-color": ["@types/d3-color@3.1.3", "", {}, "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A=="],
+
+    "@types/d3-ease": ["@types/d3-ease@3.0.2", "", {}, "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA=="],
+
+    "@types/d3-interpolate": ["@types/d3-interpolate@3.0.4", "", { "dependencies": { "@types/d3-color": "*" } }, "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA=="],
+
+    "@types/d3-path": ["@types/d3-path@3.1.1", "", {}, "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg=="],
+
+    "@types/d3-scale": ["@types/d3-scale@4.0.9", "", { "dependencies": { "@types/d3-time": "*" } }, "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw=="],
+
+    "@types/d3-shape": ["@types/d3-shape@3.1.8", "", { "dependencies": { "@types/d3-path": "*" } }, "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w=="],
+
+    "@types/d3-time": ["@types/d3-time@3.0.4", "", {}, "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g=="],
+
+    "@types/d3-timer": ["@types/d3-timer@3.0.2", "", {}, "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw=="],
+
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
@@ -875,6 +894,28 @@
 
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
+    "d3-array": ["d3-array@3.2.4", "", { "dependencies": { "internmap": "1 - 2" } }, "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg=="],
+
+    "d3-color": ["d3-color@3.1.0", "", {}, "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA=="],
+
+    "d3-ease": ["d3-ease@3.0.1", "", {}, "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w=="],
+
+    "d3-format": ["d3-format@3.1.2", "", {}, "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg=="],
+
+    "d3-interpolate": ["d3-interpolate@3.0.1", "", { "dependencies": { "d3-color": "1 - 3" } }, "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g=="],
+
+    "d3-path": ["d3-path@3.1.0", "", {}, "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ=="],
+
+    "d3-scale": ["d3-scale@4.0.2", "", { "dependencies": { "d3-array": "2.10.0 - 3", "d3-format": "1 - 3", "d3-interpolate": "1.2.0 - 3", "d3-time": "2.1.1 - 3", "d3-time-format": "2 - 4" } }, "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ=="],
+
+    "d3-shape": ["d3-shape@3.2.0", "", { "dependencies": { "d3-path": "^3.1.0" } }, "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA=="],
+
+    "d3-time": ["d3-time@3.1.0", "", { "dependencies": { "d3-array": "2 - 3" } }, "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q=="],
+
+    "d3-time-format": ["d3-time-format@4.1.0", "", { "dependencies": { "d3-time": "1 - 3" } }, "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg=="],
+
+    "d3-timer": ["d3-timer@3.0.1", "", {}, "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="],
+
     "damerau-levenshtein": ["damerau-levenshtein@1.0.8", "", {}, "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA=="],
 
     "data-uri-to-buffer": ["data-uri-to-buffer@4.0.1", "", {}, "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="],
@@ -890,6 +931,8 @@
     "date-fns-jalali": ["date-fns-jalali@4.1.0-0", "", {}, "sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg=="],
 
     "debug": ["debug@4.4.1", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ=="],
+
+    "decimal.js-light": ["decimal.js-light@2.5.1", "", {}, "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.2.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-c6fcElNV6ShtZXmsgNgFFV5tVX2PaV4g+MOAkb8eXHvn6sryJBrZa9r0zV6+dtTyoCKxtDy5tyQ5ZwQuidtd+Q=="],
 
@@ -912,6 +955,8 @@
     "dexie": ["dexie@4.3.0", "", {}, "sha512-5EeoQpJvMKHe6zWt/FSIIuRa3CWlZeIl6zKXt+Lz7BU6RoRRLgX9dZEynRfXrkLcldKYCBiz7xekTEylnie1Ug=="],
 
     "doctrine": ["doctrine@2.1.0", "", { "dependencies": { "esutils": "^2.0.2" } }, "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw=="],
+
+    "dom-helpers": ["dom-helpers@5.2.1", "", { "dependencies": { "@babel/runtime": "^7.8.7", "csstype": "^3.0.2" } }, "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA=="],
 
     "drizzle-kit": ["drizzle-kit@0.31.8", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.25.4", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-O9EC/miwdnRDY10qRxM8P3Pg8hXe3LyU4ZipReKOgTwn4OqANmftj8XJz1UPUAS6NMHf0E2htjsbQujUTkncCg=="],
 
@@ -990,6 +1035,8 @@
     "estree-util-is-identifier-name": ["estree-util-is-identifier-name@3.0.0", "", {}, "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg=="],
 
     "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
+    "eventemitter3": ["eventemitter3@4.0.7", "", {}, "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
 
@@ -1094,6 +1141,8 @@
     "inline-style-parser": ["inline-style-parser@0.2.4", "", {}, "sha512-0aO8FkhNZlj/ZIbNi7Lxxr12obT7cL1moPfE4tg1LkX7LlLfC6DeX4l2ZEud1ukP9jNQyNnfzQVqwbwmAATY4Q=="],
 
     "internal-slot": ["internal-slot@1.1.0", "", { "dependencies": { "es-errors": "^1.3.0", "hasown": "^2.0.2", "side-channel": "^1.1.0" } }, "sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw=="],
+
+    "internmap": ["internmap@2.0.3", "", {}, "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg=="],
 
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
@@ -1228,6 +1277,8 @@
     "linkifyjs": ["linkifyjs@4.3.2", "", {}, "sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA=="],
 
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
+
+    "lodash": ["lodash@4.17.23", "", {}, "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w=="],
 
     "lodash.merge": ["lodash.merge@4.6.2", "", {}, "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="],
 
@@ -1451,7 +1502,7 @@
 
     "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
-    "react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
+    "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 
     "react-markdown": ["react-markdown@10.1.0", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/mdast": "^4.0.0", "devlop": "^1.0.0", "hast-util-to-jsx-runtime": "^2.0.0", "html-url-attributes": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "remark-parse": "^11.0.0", "remark-rehype": "^11.0.0", "unified": "^11.0.0", "unist-util-visit": "^5.0.0", "vfile": "^6.0.0" }, "peerDependencies": { "@types/react": ">=18", "react": ">=18" } }, "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ=="],
 
@@ -1459,7 +1510,15 @@
 
     "react-remove-scroll-bar": ["react-remove-scroll-bar@2.3.8", "", { "dependencies": { "react-style-singleton": "^2.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" }, "optionalPeers": ["@types/react"] }, "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q=="],
 
+    "react-smooth": ["react-smooth@4.0.4", "", { "dependencies": { "fast-equals": "^5.0.1", "prop-types": "^15.8.1", "react-transition-group": "^4.4.5" }, "peerDependencies": { "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q=="],
+
     "react-style-singleton": ["react-style-singleton@2.2.3", "", { "dependencies": { "get-nonce": "^1.0.0", "tslib": "^2.0.0" }, "peerDependencies": { "@types/react": "*", "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react"] }, "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ=="],
+
+    "react-transition-group": ["react-transition-group@4.4.5", "", { "dependencies": { "@babel/runtime": "^7.5.5", "dom-helpers": "^5.0.1", "loose-envify": "^1.4.0", "prop-types": "^15.6.2" }, "peerDependencies": { "react": ">=16.6.0", "react-dom": ">=16.6.0" } }, "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g=="],
+
+    "recharts": ["recharts@2.15.4", "", { "dependencies": { "clsx": "^2.0.0", "eventemitter3": "^4.0.1", "lodash": "^4.17.21", "react-is": "^18.3.1", "react-smooth": "^4.0.4", "recharts-scale": "^0.4.4", "tiny-invariant": "^1.3.1", "victory-vendor": "^36.6.8" }, "peerDependencies": { "react": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0", "react-dom": "^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw=="],
+
+    "recharts-scale": ["recharts-scale@0.4.5", "", { "dependencies": { "decimal.js-light": "^2.4.1" } }, "sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w=="],
 
     "reflect.getprototypeof": ["reflect.getprototypeof@1.0.10", "", { "dependencies": { "call-bind": "^1.0.8", "define-properties": "^1.2.1", "es-abstract": "^1.23.9", "es-errors": "^1.3.0", "es-object-atoms": "^1.0.0", "get-intrinsic": "^1.2.7", "get-proto": "^1.0.1", "which-builtin-type": "^1.2.1" } }, "sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw=="],
 
@@ -1569,6 +1628,8 @@
 
     "tapable": ["tapable@2.2.2", "", {}, "sha512-Re10+NauLTMCudc7T5WLFLAwDhQ0JWdrMK+9B2M8zR5hRExKmsRDCBA7/aV/pNJFltmBFO5BAMlQFi/vq3nKOg=="],
 
+    "tiny-invariant": ["tiny-invariant@1.3.3", "", {}, "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
@@ -1650,6 +1711,8 @@
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-jRDZ1IMLttGj41KcZvlrYAaI3CfqpLpfpf+Mfig13viT6NKvRzWZ+lXz0Y5D60w6uJIBAOGq9mSHf0gktF0duw=="],
+
+    "victory-vendor": ["victory-vendor@36.9.2", "", { "dependencies": { "@types/d3-array": "^3.0.3", "@types/d3-ease": "^3.0.0", "@types/d3-interpolate": "^3.0.1", "@types/d3-scale": "^4.0.2", "@types/d3-shape": "^3.1.0", "@types/d3-time": "^3.0.0", "@types/d3-timer": "^3.0.0", "d3-array": "^3.1.6", "d3-ease": "^3.0.1", "d3-interpolate": "^3.0.1", "d3-scale": "^4.0.2", "d3-shape": "^3.1.0", "d3-time": "^3.0.0", "d3-timer": "^3.0.1" } }, "sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ=="],
 
     "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
@@ -1764,6 +1827,8 @@
     "next-sitemap/@next/env": ["@next/env@13.5.11", "", {}, "sha512-fbb2C7HChgM7CemdCY+y3N1n8pcTKdqtQLbC7/EQtPdLvlMUT9JX/dBYl8MMZAtYG4uVMyPFHXckb68q/NRwqg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
     "@esbuild-kit/core-utils/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.18.20", "", { "os": "android", "cpu": "arm" }, "sha512-fyi7TDI/ijKKNZTUJAQqiG5T7YjJXgnzkURqmGj13C6dCqckZBLdl4h7bkhHt/t0WP+zO9/zwroDvANaOqO5Sw=="],
 


### PR DESCRIPTION
## Summary

- Add a full data dashboard to the admin panel with KPIs, growth charts, and demographic distributions
- Create a read-only DAL with 6 cached query functions that reuse existing cache tags from artistas/eventos features
- Implement a Bento-grid UI layout with KPI cards, area chart for festival growth, donut chart for disciplines, and supporting stat widgets

## Changes

### DAL (`src/app/(authenticated)/(dashboard)/dashboard/_lib/get-dashboard-stats.ts`)
- `getDashboardArtistStats()` — artist counts by status, catalog active count, data completeness
- `getDashboardEventStats()` — total participations/editions, latest edition info
- `getDashboardGrowthData()` — participant counts per festival edition
- `getDashboardDisciplineData()` — exhibition counts by discipline
- `getDashboardTopArtists()` — top 5 artists by participation count
- `getDashboardGeographicData()` — top 6 cities by artist count

All functions use `'use cache'` with `cacheTag(...)` reusing existing tags (`admin:artistas`, `admin:eventos`, etc.) so cache invalidation works across features.

### UI Components
- KPI cards: Total Artists, Historic Participations, Active Catalog, Last Edition
- Festival Growth Chart: Area chart showing participation growth over 15 Festival editions
- Discipline Donut: Pie chart showing discipline distribution
- Data Health: Progress bars showing data completeness (email/phone/RUT %)
- Geography: Ranked city list with visual weight
- Top Artists: Top 5 recurring artists

### Tech
- Shadcn Charts (Recharts) for visualizations
- Server Components with Suspense boundaries
- TypeScript strict mode
- Shared cache tags for coordinated invalidation

## Verification

- `bun run type-check` ✅
- `bun run lint` ✅  
- `bun run build` ✅