### PR TITLE
feat(artistas): add entity dialogs for artistas and catalogo

### DIFF
--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
@@ -1,0 +1,242 @@
+'use client'
+
+import { useState } from 'react'
+import { EntityFormDialog } from '@/shared/components/entity-form-dialog/entity-form-dialog'
+import { Button } from '@/shared/components/ui/button'
+import { Input } from '@/shared/components/ui/input'
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+  FieldError
+} from '@/shared/components/ui/field'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/shared/components/ui/select'
+import { useArtistDialog } from '../_store/artist-dialog-store'
+import { useArtistsOperationStore } from '../_store/artista-ui-store'
+import { artistaFormSchema } from '../_schemas/artista.schema'
+
+function toSlug(str: string): string {
+  return str
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, '-')
+    .replace(/[^a-z0-9-]/g, '')
+    .replace(/-+/g, '-')
+}
+
+const STATUS_SLUG_MAP: Record<number, string> = {
+  1: 'desconocido',
+  2: 'activo',
+  3: 'inactivo',
+  4: 'vetado',
+  5: 'cancelado'
+}
+
+type AddArtistFormData = {
+  pseudonimo: string
+  nombre: string
+  correo: string
+  estadoId: string
+  ciudad: string
+  pais: string
+}
+
+function AddArtistFormContent({
+  onApply,
+  onCancel
+}: {
+  onApply: (data: AddArtistFormData) => void
+  onCancel: () => void
+}) {
+  const [formData, setFormData] = useState({
+    pseudonimo: '',
+    nombre: '',
+    correo: '',
+    estadoId: '2',
+    ciudad: '',
+    pais: ''
+  })
+  const [errors, setErrors] = useState<{
+    pseudonimo?: string
+    estadoId?: string
+  }>({})
+
+  const handlePseudonimoChange = (val: string) => {
+    setFormData((prev) => ({ ...prev, pseudonimo: val }))
+  }
+
+  const handleApply = () => {
+    setErrors({})
+    const result = artistaFormSchema.safeParse({
+      pseudonimo: formData.pseudonimo,
+      slug: toSlug(formData.pseudonimo), // auto-generate slug
+      nombre: formData.nombre || undefined,
+      correo: formData.correo || undefined,
+      ciudad: formData.ciudad || undefined,
+      pais: formData.pais || undefined,
+      estadoId: formData.estadoId
+    })
+
+    if (!result.success) {
+      const fieldErrors: {
+        pseudonimo?: string
+        estadoId?: string
+      } = {}
+      for (const issue of result.error.issues) {
+        if (issue.path[0] === 'pseudonimo')
+          fieldErrors.pseudonimo = issue.message
+        if (issue.path[0] === 'estadoId') fieldErrors.estadoId = issue.message
+      }
+      setErrors(fieldErrors)
+      return
+    }
+
+    onApply(formData)
+  }
+
+  return (
+    <FieldGroup>
+      <Field>
+        <FieldLabel htmlFor='pseudonimo'>
+          Pseudónimo <span className='text-destructive'>*</span>
+        </FieldLabel>
+        <Input
+          id='pseudonimo'
+          value={formData.pseudonimo}
+          onChange={(e) => handlePseudonimoChange(e.target.value)}
+          placeholder='@usuario'
+          aria-invalid={!!errors.pseudonimo}
+        />
+        {errors.pseudonimo && <FieldError>{errors.pseudonimo}</FieldError>}
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
+        <Input
+          id='nombre'
+          value={formData.nombre}
+          onChange={(e) =>
+            setFormData((prev) => ({ ...prev, nombre: e.target.value }))
+          }
+          placeholder='Nombre completo'
+        />
+      </Field>
+
+      <div className='grid grid-cols-2 gap-4'>
+        <Field>
+          <FieldLabel htmlFor='correo'>Correo electrónico</FieldLabel>
+          <Input
+            id='correo'
+            type='email'
+            value={formData.correo}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, correo: e.target.value }))
+            }
+            placeholder='artista@ejemplo.com'
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor='estadoId'>Estado</FieldLabel>
+          <Select
+            value={formData.estadoId}
+            onValueChange={(val) =>
+              setFormData((prev) => ({ ...prev, estadoId: val as string }))
+            }
+          >
+            <SelectTrigger id='estadoId'>
+              <SelectValue placeholder='Estado' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='2'>Activo</SelectItem>
+              <SelectItem value='3'>Inactivo</SelectItem>
+              <SelectItem value='4'>Vetado</SelectItem>
+              <SelectItem value='5'>Cancelado</SelectItem>
+              <SelectItem value='1'>Desconocido</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors.estadoId && <FieldError>{errors.estadoId}</FieldError>}
+        </Field>
+      </div>
+
+      <div className='grid grid-cols-2 gap-4'>
+        <Field>
+          <FieldLabel htmlFor='ciudad'>Ciudad</FieldLabel>
+          <Input
+            id='ciudad'
+            value={formData.ciudad}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, ciudad: e.target.value }))
+            }
+            placeholder='Santiago'
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor='pais'>País</FieldLabel>
+          <Input
+            id='pais'
+            value={formData.pais}
+            onChange={(e) =>
+              setFormData((prev) => ({ ...prev, pais: e.target.value }))
+            }
+            placeholder='Chile'
+          />
+        </Field>
+      </div>
+
+      <div className='flex justify-end gap-2 pt-4'>
+        <Button variant='outline' onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button onClick={handleApply}>Agregar artista</Button>
+      </div>
+    </FieldGroup>
+  )
+}
+
+export function AddArtistDialog() {
+  const addDialogOpen = useArtistDialog((s) => s.addDialogOpen)
+  const closeAddDialog = useArtistDialog((s) => s.closeAddDialog)
+  const add = useArtistsOperationStore((s) => s.add)
+
+  const handleApply = (formData: AddArtistFormData) => {
+    const numericEstadoId = Number(formData.estadoId)
+    const generatedSlug = toSlug(formData.pseudonimo)
+    add({
+      nombre: formData.nombre.trim() || null,
+      pseudonimo: formData.pseudonimo.trim(),
+      slug: generatedSlug,
+      rut: null,
+      correo: formData.correo.trim() || null,
+      telefono: null,
+      ciudad: formData.ciudad.trim() || null,
+      pais: formData.pais.trim() || null,
+      rrss: null,
+      estadoId: numericEstadoId,
+      estadoSlug: STATUS_SLUG_MAP[numericEstadoId] ?? 'desconocido',
+      deletedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    })
+    closeAddDialog()
+  }
+
+  return (
+    <EntityFormDialog
+      open={addDialogOpen}
+      onOpenChange={(open) => !open && closeAddDialog()}
+      title='Agregar Artista'
+    >
+      {addDialogOpen && (
+        <AddArtistFormContent onApply={handleApply} onCancel={closeAddDialog} />
+      )}
+    </EntityFormDialog>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
@@ -21,6 +21,8 @@ import { useArtistDialog } from '../_store/artist-dialog-store'
 import { useArtistsOperationStore } from '../_store/artista-ui-store'
 import { artistaFormSchema } from '../_schemas/artista.schema'
 
+import { ArtistFormLayout } from '@/shared/components/artist-form/artist-form'
+
 function toSlug(str: string): string {
   return str
     .normalize('NFD')
@@ -43,6 +45,8 @@ const STATUS_SLUG_MAP: Record<number, string> = {
 type AddArtistFormData = {
   pseudonimo: string
   nombre: string
+  rut: string
+  telefono: string
   correo: string
   estadoId: string
   ciudad: string
@@ -59,6 +63,8 @@ function AddArtistFormContent({
   const [formData, setFormData] = useState({
     pseudonimo: '',
     nombre: '',
+    rut: '',
+    telefono: '',
     correo: '',
     estadoId: '2',
     ciudad: '',
@@ -73,16 +79,21 @@ function AddArtistFormContent({
     setFormData((prev) => ({ ...prev, pseudonimo: val }))
   }
 
+  const handleFieldChange = (field: string, val: string) => {
+    setFormData((prev) => ({ ...prev, [field]: val }))
+  }
+
   const handleApply = () => {
     setErrors({})
     const result = artistaFormSchema.safeParse({
-      pseudonimo: formData.pseudonimo,
-      slug: toSlug(formData.pseudonimo), // auto-generate slug
+      ...formData,
+      slug: toSlug(formData.pseudonimo),
       nombre: formData.nombre || undefined,
+      rut: formData.rut || undefined,
+      telefono: formData.telefono || undefined,
       correo: formData.correo || undefined,
       ciudad: formData.ciudad || undefined,
-      pais: formData.pais || undefined,
-      estadoId: formData.estadoId
+      pais: formData.pais || undefined
     })
 
     if (!result.success) {
@@ -103,101 +114,20 @@ function AddArtistFormContent({
   }
 
   return (
-    <FieldGroup>
-      <Field>
-        <FieldLabel htmlFor='pseudonimo'>
-          Pseudónimo <span className='text-destructive'>*</span>
-        </FieldLabel>
-        <Input
-          id='pseudonimo'
-          value={formData.pseudonimo}
-          onChange={(e) => handlePseudonimoChange(e.target.value)}
-          placeholder='@usuario'
-          aria-invalid={!!errors.pseudonimo}
-        />
-        {errors.pseudonimo && <FieldError>{errors.pseudonimo}</FieldError>}
-      </Field>
-
-      <Field>
-        <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
-        <Input
-          id='nombre'
-          value={formData.nombre}
-          onChange={(e) =>
-            setFormData((prev) => ({ ...prev, nombre: e.target.value }))
-          }
-          placeholder='Nombre completo'
-        />
-      </Field>
-
-      <div className='grid grid-cols-2 gap-4'>
-        <Field>
-          <FieldLabel htmlFor='correo'>Correo electrónico</FieldLabel>
-          <Input
-            id='correo'
-            type='email'
-            value={formData.correo}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, correo: e.target.value }))
-            }
-            placeholder='artista@ejemplo.com'
-          />
-        </Field>
-        <Field>
-          <FieldLabel htmlFor='estadoId'>Estado</FieldLabel>
-          <Select
-            value={formData.estadoId}
-            onValueChange={(val) =>
-              setFormData((prev) => ({ ...prev, estadoId: val as string }))
-            }
-          >
-            <SelectTrigger id='estadoId'>
-              <SelectValue placeholder='Estado' />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value='2'>Activo</SelectItem>
-              <SelectItem value='3'>Inactivo</SelectItem>
-              <SelectItem value='4'>Vetado</SelectItem>
-              <SelectItem value='5'>Cancelado</SelectItem>
-              <SelectItem value='1'>Desconocido</SelectItem>
-            </SelectContent>
-          </Select>
-          {errors.estadoId && <FieldError>{errors.estadoId}</FieldError>}
-        </Field>
-      </div>
-
-      <div className='grid grid-cols-2 gap-4'>
-        <Field>
-          <FieldLabel htmlFor='ciudad'>Ciudad</FieldLabel>
-          <Input
-            id='ciudad'
-            value={formData.ciudad}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, ciudad: e.target.value }))
-            }
-            placeholder='Santiago'
-          />
-        </Field>
-        <Field>
-          <FieldLabel htmlFor='pais'>País</FieldLabel>
-          <Input
-            id='pais'
-            value={formData.pais}
-            onChange={(e) =>
-              setFormData((prev) => ({ ...prev, pais: e.target.value }))
-            }
-            placeholder='Chile'
-          />
-        </Field>
-      </div>
-
-      <div className='flex justify-end gap-2 pt-4'>
-        <Button variant='outline' onClick={onCancel}>
-          Cancelar
-        </Button>
-        <Button onClick={handleApply}>Agregar artista</Button>
-      </div>
-    </FieldGroup>
+    <ArtistFormLayout
+      formData={formData}
+      errors={errors}
+      onFieldChange={handleFieldChange}
+      customFields={null}
+      actions={
+        <div className='flex justify-end gap-2 pt-4'>
+          <Button variant='outline' onClick={onCancel}>
+            Cancelar
+          </Button>
+          <Button onClick={handleApply}>Agregar artista</Button>
+        </div>
+      }
+    />
   )
 }
 
@@ -213,9 +143,9 @@ export function AddArtistDialog() {
       nombre: formData.nombre.trim() || null,
       pseudonimo: formData.pseudonimo.trim(),
       slug: generatedSlug,
-      rut: null,
+      rut: formData.rut.trim() || null,
       correo: formData.correo.trim() || null,
-      telefono: null,
+      telefono: formData.telefono.trim() || null,
       ciudad: formData.ciudad.trim() || null,
       pais: formData.pais.trim() || null,
       rrss: null,

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
@@ -3,20 +3,6 @@
 import { useState } from 'react'
 import { EntityFormDialog } from '@/shared/components/entity-form-dialog/entity-form-dialog'
 import { Button } from '@/shared/components/ui/button'
-import { Input } from '@/shared/components/ui/input'
-import {
-  Field,
-  FieldGroup,
-  FieldLabel,
-  FieldError
-} from '@/shared/components/ui/field'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/shared/components/ui/select'
 import { useArtistDialog } from '../_store/artist-dialog-store'
 import { useArtistsOperationStore } from '../_store/artista-ui-store'
 import { artistaFormSchema } from '../_schemas/artista.schema'

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/add-artist-dialog.tsx
@@ -75,10 +75,6 @@ function AddArtistFormContent({
     estadoId?: string
   }>({})
 
-  const handlePseudonimoChange = (val: string) => {
-    setFormData((prev) => ({ ...prev, pseudonimo: val }))
-  }
-
   const handleFieldChange = (field: string, val: string) => {
     setFormData((prev) => ({ ...prev, [field]: val }))
   }

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-container.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-container.tsx
@@ -14,9 +14,13 @@ import { ArtistListFilters } from './artist-list-filters'
 import { ArtistListPagination } from './artist-list-pagination'
 import { ArtistListTable } from './artist-list-table'
 import { EditArtistDialog } from './edit-artist-dialog'
+import { AddArtistDialog } from './add-artist-dialog'
 import { ArtistHistoryDialog } from './artist-history-dialog'
 import { useHistoryByArtist } from '../_hooks/use-history-by-artist'
+import { useArtistDialog } from '../_store/artist-dialog-store'
 import type { HistoryEntry } from '../_types'
+import { Button } from '@/shared/components/ui/button'
+import { Plus } from 'lucide-react'
 
 export function ArtistListContainer({
   historyData
@@ -151,6 +155,8 @@ export function ArtistListContainer({
     })
   }
 
+  const openAddDialog = useArtistDialog((s) => s.openAddDialog)
+
   return (
     <div className='grid space-y-4'>
       <div className='flex items-center justify-between gap-4'>
@@ -159,6 +165,10 @@ export function ArtistListContainer({
           cities={cities}
           onFiltersChange={handleFiltersChange}
         />
+        <Button size='sm' variant='outline' onClick={openAddDialog} className='gap-1'>
+          <Plus className='h-4 w-4' />
+          Agregar artista
+        </Button>
       </div>
 
       <ArtistListPagination onPageChange={handlePageChange} />
@@ -171,6 +181,7 @@ export function ArtistListContainer({
       <ArtistListPagination onPageChange={handlePageChange} />
 
       <EditArtistDialog />
+      <AddArtistDialog />
       <ArtistHistoryDialog historyByArtistId={historyByArtistId} />
 
       {/* TODO: Verify sequential commit ordering and ID mapping for multi-entity routes */}

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-row.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-row.tsx
@@ -11,6 +11,7 @@ import {
 import { useArtistDialog } from '../_store/artist-dialog-store'
 import { StateBadge } from '@/shared/components/state-badge'
 import { ActionMenuButton } from '@/shared/components/action-menu-button'
+import { RRSSViewer } from '@/shared/components/rrss-viewer/rrss-viewer'
 
 interface ArtistListRowProps {
   id: string
@@ -61,6 +62,9 @@ export const ArtistListRow = memo(function ArtistListRow({
       <TableCell>{artist.correo || '-'}</TableCell>
       <TableCell>
         {[artist.ciudad, artist.pais].filter(Boolean).join(', ') || '-'}
+      </TableCell>
+      <TableCell>
+        <RRSSViewer rrss={artist.rrss} disabled={isDeleted} />
       </TableCell>
       <TableCell className='text-muted-foreground'>
         {artist.rut || '-'}

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-table.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/artist-list-table.tsx
@@ -56,6 +56,7 @@ export const ArtistListTable = memo(function ArtistListTable({
             <TableHead>Nombre</TableHead>
             <TableHead>Correo</TableHead>
             <TableHead>Ubicación</TableHead>
+            <TableHead>RRSS</TableHead>
             <TableHead>RUT</TableHead>
             <TableHead>Estado</TableHead>
             <TableHead>Acciones</TableHead>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
@@ -8,14 +8,6 @@ import {
   DialogTitle
 } from '@/shared/components/ui/dialog'
 import { Button } from '@/shared/components/ui/button'
-import { Input } from '@/shared/components/ui/input'
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue
-} from '@/shared/components/ui/select'
 import {
   useArtistsOperationStore,
   useArtistsProjectionStore
@@ -173,7 +165,6 @@ export function EditFormContent({
           )}
         </>
       }
-
       actions={
         <>
           <ArtistRRSSManager initialValue={artist.rrss} onChange={updateRRSS} />

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_components/edit-artist-dialog.tsx
@@ -23,7 +23,7 @@ import {
 import { useArtistDialog } from '../_store/artist-dialog-store'
 import { ArtistRRSSManager } from '../catalogo/_components/artist-rrss-manager'
 import type { ArtistEntry } from '../_types'
-import { Field, FieldGroup, FieldLabel } from '@/shared/components/ui/field'
+import { ArtistFormLayout } from '@/shared/components/artist-form/artist-form'
 import { Switch } from '@/shared/components/ui/switch'
 import { Label } from '@/shared/components/ui/label'
 
@@ -39,6 +39,8 @@ export function EditFormContent({
   const [formData, setFormData] = useState({
     nombre: artist.nombre ?? '',
     pseudonimo: artist.pseudonimo ?? '',
+    rut: artist.rut ?? '',
+    telefono: artist.telefono ?? '',
     correo: artist.correo ?? '',
     rrss: artist.rrss ?? {},
     city: artist.ciudad ?? '',
@@ -111,6 +113,8 @@ export function EditFormContent({
     update(artist.id, {
       nombre: formData.nombre,
       pseudonimo: formData.pseudonimo,
+      rut: formData.rut,
+      telefono: formData.telefono,
       correo: formData.correo,
       rrss: formData.rrss,
       ciudad: formData.city,
@@ -123,29 +127,30 @@ export function EditFormContent({
     onClose()
   }
 
+  const layoutFormData = {
+    nombre: formData.nombre,
+    pseudonimo: formData.pseudonimo,
+    rut: formData.rut,
+    telefono: formData.telefono,
+    correo: formData.correo,
+    estadoId: formData.statusId,
+    ciudad: formData.city,
+    pais: formData.country
+  }
+
+  const handleFieldChange = (field: string, value: string) => {
+    if (field === 'ciudad') updateField('city', value)
+    else if (field === 'pais') updateField('country', value)
+    else if (field === 'estadoId') updateField('statusId', Number(value))
+    else updateField(field as keyof typeof formData, value)
+  }
+
   return (
-    <>
-      <FieldGroup>
-        <Field>
-          <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
-          <Input
-            id='nombre'
-            value={formData.nombre}
-            onChange={(e) => updateField('nombre', e.target.value)}
-            placeholder='Nombre completo'
-          />
-        </Field>
-        <Field>
-          <FieldLabel htmlFor='pseudonimo'>
-            Pseudónimo <span className='text-destructive'>*</span>
-          </FieldLabel>
-          <Input
-            id='pseudonimo'
-            value={formData.pseudonimo}
-            onChange={(e) => updateField('pseudonimo', e.target.value)}
-            placeholder='@usuario'
-            required
-          />
+    <ArtistFormLayout
+      formData={layoutFormData}
+      onFieldChange={handleFieldChange}
+      customFields={
+        <>
           {hasChanged.pseudonimo && (
             <div className='mt-1 flex items-center gap-2'>
               <Switch
@@ -166,148 +171,39 @@ export function EditFormContent({
               </Label>
             </div>
           )}
-        </Field>
+        </>
+      }
 
-        <div className='grid grid-cols-2 gap-4'>
-          <Field>
-            <FieldLabel htmlFor='correo'>Correo electrónico</FieldLabel>
-            <Input
-              id='correo'
-              type='email'
-              value={formData.correo}
-              onChange={(e) => updateField('correo', e.target.value)}
-              placeholder='artista@ejemplo.com'
-            />
-            {hasChanged.correo && (
-              <div className='mt-1 flex items-center gap-2'>
-                <Switch
-                  id='historial-correo'
-                  checked={historialChecks.correo}
-                  onCheckedChange={(checked) =>
-                    setHistorialChecks((prev) => ({ ...prev, correo: checked }))
-                  }
-                />
-                <Label
-                  htmlFor='historial-correo'
-                  className='text-muted-foreground cursor-pointer text-xs font-normal'
-                >
-                  Guardar valor anterior en historial
-                </Label>
-              </div>
-            )}
-          </Field>
-          <Field>
-            <FieldLabel htmlFor='estadoId'>Estado</FieldLabel>
-            <Select
-              value={String(formData.statusId)}
-              onValueChange={(v) => updateField('statusId', Number(v))}
-            >
-              <SelectTrigger>
-                <SelectValue placeholder='Estado'>
-                  {formData.statusId === 2
-                    ? 'Activo'
-                    : formData.statusId === 3
-                      ? 'Inactivo'
-                      : formData.statusId === 4
-                        ? 'Vetado'
-                        : formData.statusId === 5
-                          ? 'Cancelado'
-                          : 'Desconocido'}
-                </SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value='2'>Activo</SelectItem>
-                <SelectItem value='3'>Inactivo</SelectItem>
-                <SelectItem value='4'>Vetado</SelectItem>
-                <SelectItem value='5'>Cancelado</SelectItem>
-                <SelectItem value='1'>Desconocido</SelectItem>
-              </SelectContent>
-            </Select>
-          </Field>
-        </div>
+      actions={
+        <>
+          <ArtistRRSSManager initialValue={artist.rrss} onChange={updateRRSS} />
+          {hasChanged.rrss && (
+            <div className='mt-1 flex items-center gap-2'>
+              <Switch
+                id='historial-rrss'
+                checked={historialChecks.rrss}
+                onCheckedChange={(checked) =>
+                  setHistorialChecks((prev) => ({ ...prev, rrss: checked }))
+                }
+              />
+              <Label
+                htmlFor='historial-rrss'
+                className='text-muted-foreground cursor-pointer text-xs font-normal'
+              >
+                Guardar valor anterior en historial
+              </Label>
+            </div>
+          )}
 
-        <div className='grid grid-cols-2 gap-4'>
-          <Field>
-            <FieldLabel htmlFor='ciudad'>Ciudad</FieldLabel>
-            <Input
-              id='ciudad'
-              value={formData.city}
-              onChange={(e) => updateField('city', e.target.value)}
-              placeholder='Santiago'
-            />
-            {hasChanged.ciudad && (
-              <div className='mt-1 flex items-center gap-2'>
-                <Switch
-                  id='historial-ciudad'
-                  checked={historialChecks.ciudad}
-                  onCheckedChange={(checked) =>
-                    setHistorialChecks((prev) => ({ ...prev, ciudad: checked }))
-                  }
-                />
-                <Label
-                  htmlFor='historial-ciudad'
-                  className='text-muted-foreground cursor-pointer text-xs font-normal'
-                >
-                  Guardar valor anterior en historial
-                </Label>
-              </div>
-            )}
-          </Field>
-          <Field>
-            <FieldLabel htmlFor='pais'>País</FieldLabel>
-            <Input
-              id='pais'
-              value={formData.country}
-              onChange={(e) => updateField('country', e.target.value)}
-              placeholder='Chile'
-            />
-            {hasChanged.pais && (
-              <div className='mt-1 flex items-center gap-2'>
-                <Switch
-                  id='historial-pais'
-                  checked={historialChecks.pais}
-                  onCheckedChange={(checked) =>
-                    setHistorialChecks((prev) => ({ ...prev, pais: checked }))
-                  }
-                />
-                <Label
-                  htmlFor='historial-pais'
-                  className='text-muted-foreground cursor-pointer text-xs font-normal'
-                >
-                  Guardar valor anterior en historial
-                </Label>
-              </div>
-            )}
-          </Field>
-        </div>
-
-        <ArtistRRSSManager initialValue={artist.rrss} onChange={updateRRSS} />
-        {hasChanged.rrss && (
-          <div className='mt-1 flex items-center gap-2'>
-            <Switch
-              id='historial-rrss'
-              checked={historialChecks.rrss}
-              onCheckedChange={(checked) =>
-                setHistorialChecks((prev) => ({ ...prev, rrss: checked }))
-              }
-            />
-            <Label
-              htmlFor='historial-rrss'
-              className='text-muted-foreground cursor-pointer text-xs font-normal'
-            >
-              Guardar valor anterior en historial
-            </Label>
+          <div className='flex justify-end gap-2 pt-4'>
+            <Button variant='outline' onClick={onClose}>
+              Cancelar
+            </Button>
+            <Button onClick={handleSave}>Confirmar Edición</Button>
           </div>
-        )}
-      </FieldGroup>
-
-      <div className='flex justify-end gap-2 pt-4'>
-        <Button variant='outline' onClick={onClose}>
-          Cancelar
-        </Button>
-        <Button onClick={handleSave}>Confirmar Edición</Button>
-      </div>
-    </>
+        </>
+      }
+    />
   )
 }
 

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/_store/artist-dialog-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/_store/artist-dialog-store.ts
@@ -1,11 +1,14 @@
 import { create } from 'zustand'
 
 interface ArtistDialogStore {
+  addDialogOpen: boolean
   editDialogOpen: boolean
   selectedArtistId: string | null
   historyDialogOpen: boolean
   selectedHistoryArtistId: string | null
 
+  openAddDialog: () => void
+  closeAddDialog: () => void
   openEditDialog: (id: string) => void
   closeEditDialog: () => void
   openHistoryDialog: (id: string) => void
@@ -13,11 +16,14 @@ interface ArtistDialogStore {
 }
 
 export const useArtistDialog = create<ArtistDialogStore>((set) => ({
+  addDialogOpen: false,
   editDialogOpen: false,
   selectedArtistId: null,
   historyDialogOpen: false,
   selectedHistoryArtistId: null,
 
+  openAddDialog: () => set({ addDialogOpen: true }),
+  closeAddDialog: () => set({ addDialogOpen: false }),
   openEditDialog: (id) => set({ editDialogOpen: true, selectedArtistId: id }),
   closeEditDialog: () => set({ editDialogOpen: false, selectedArtistId: null }),
   openHistoryDialog: (id) =>

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
@@ -18,6 +18,7 @@ import {
   FieldGroup,
   FieldLabel
 } from '@/shared/components/ui/field'
+import { Input } from '@/shared/components/ui/input'
 import { Switch } from '@/shared/components/ui/switch'
 import { Textarea } from '@/shared/components/ui/textarea'
 import { Label } from '@/shared/components/ui/label'
@@ -47,6 +48,7 @@ function AddCatalogFormContent({
   onCancel
 }: AddCatalogFormContentProps) {
   const [selectedArtist, setSelectedArtist] = useState<ArtistItem | null>(null)
+  const [inputValue, setInputValue] = useState('')
   const [descripcion, setDescripcion] = useState('')
   const [destacado, setDestacado] = useState(false)
   const [activo, setActivo] = useState(true)
@@ -70,6 +72,9 @@ function AddCatalogFormContent({
       value: id,
       label: artistById[id]?.pseudonimo ?? id
     }))
+    .filter((item) =>
+      item.label.toLowerCase().includes(inputValue.toLowerCase())
+    )
 
   const handleApply = () => {
     if (!selectedArtist) {
@@ -107,6 +112,8 @@ function AddCatalogFormContent({
         <Combobox
           items={availableItems}
           value={selectedArtist}
+          inputValue={inputValue}
+          onInputValueChange={setInputValue}
           onValueChange={(item) => {
             setSelectedArtist(item)
             setErrors((prev) => ({ ...prev, artistaId: undefined }))

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
@@ -1,0 +1,205 @@
+'use client'
+
+import { useState } from 'react'
+import { generateKeyBetween } from 'fractional-indexing'
+import { EntityFormDialog } from '@/shared/components/entity-form-dialog/entity-form-dialog'
+import { Button } from '@/shared/components/ui/button'
+import {
+  Combobox,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxList
+} from '@/shared/components/ui/combobox'
+import {
+  Field,
+  FieldError,
+  FieldGroup,
+  FieldLabel
+} from '@/shared/components/ui/field'
+import { Switch } from '@/shared/components/ui/switch'
+import { Textarea } from '@/shared/components/ui/textarea'
+import { Label } from '@/shared/components/ui/label'
+
+import { useCatalogViewStore } from '../_store/catalog-view-store'
+import {
+  useCatalogOperationStore,
+  useCatalogProjectionStore
+} from '../_store/catalog-ui-store'
+import { useArtistsProjectionStore } from '../../_store/artista-ui-store'
+
+type ArtistItem = { value: string; label: string }
+
+interface AddCatalogFormContentProps {
+  onApply: (data: {
+    artistaId: string
+    orden: string
+    destacado: boolean
+    activo: boolean
+    descripcion: string | null
+  }) => void
+  onCancel: () => void
+}
+
+function AddCatalogFormContent({
+  onApply,
+  onCancel
+}: AddCatalogFormContentProps) {
+  const [selectedArtist, setSelectedArtist] = useState<ArtistItem | null>(null)
+  const [descripcion, setDescripcion] = useState('')
+  const [destacado, setDestacado] = useState(false)
+  const [activo, setActivo] = useState(true)
+  const [errors, setErrors] = useState<{ artistaId?: string }>({})
+
+  const catalogById = useCatalogProjectionStore((s) => s.byId)
+  const catalogArtistIds = new Set(
+    Object.values(catalogById)
+      .filter((e) => !e.__meta?.isDeleted)
+      .map((e) => e.artistaId)
+  )
+
+  const artistAllIds = useArtistsProjectionStore((s) => s.allIds)
+  const artistById = useArtistsProjectionStore((s) => s.byId)
+
+  const availableItems: ArtistItem[] = artistAllIds
+    .filter((id) => !artistById[id]?.__meta?.isDeleted)
+    .filter((id) => !artistById[id]?.__meta?.isNew)
+    .filter((id) => !catalogArtistIds.has(id))
+    .map((id) => ({
+      value: id,
+      label: artistById[id]?.pseudonimo ?? id
+    }))
+
+  const handleApply = () => {
+    if (!selectedArtist) {
+      setErrors({ artistaId: 'Debes seleccionar un artista' })
+      return
+    }
+
+    const allCatalogIds = useCatalogProjectionStore.getState().allIds
+    const catalogByIdSnap = useCatalogProjectionStore.getState().byId
+    const lastOrden =
+      allCatalogIds
+        .filter((id) => !catalogByIdSnap[id]?.__meta?.isDeleted)
+        .map((id) => catalogByIdSnap[id]?.orden)
+        .filter((o): o is string => !!o)
+        .sort()
+        .at(-1) ?? null
+
+    const newOrden = generateKeyBetween(lastOrden, null)
+
+    onApply({
+      artistaId: selectedArtist.value,
+      orden: newOrden,
+      destacado,
+      activo,
+      descripcion: descripcion.trim() || null
+    })
+  }
+
+  return (
+    <FieldGroup className='pt-4'>
+      <Field>
+        <FieldLabel>
+          Artista <span className='text-destructive'>*</span>
+        </FieldLabel>
+        <Combobox
+          items={availableItems}
+          value={selectedArtist}
+          onValueChange={(item) => {
+            setSelectedArtist(item)
+            setErrors((prev) => ({ ...prev, artistaId: undefined }))
+          }}
+          isItemEqualToValue={(item, val) => item.value === val.value}
+        >
+          <ComboboxInput placeholder='Buscar artista...' showTrigger />
+          <ComboboxContent>
+            <ComboboxEmpty>
+              No hay artistas disponibles para agregar
+            </ComboboxEmpty>
+            <ComboboxList>
+              {availableItems.map((item) => (
+                <ComboboxItem key={item.value} value={item}>
+                  {item.label}
+                </ComboboxItem>
+              ))}
+            </ComboboxList>
+          </ComboboxContent>
+        </Combobox>
+        {errors.artistaId && <FieldError>{errors.artistaId}</FieldError>}
+      </Field>
+
+      <Field>
+        <FieldLabel htmlFor='descripcion'>Descripción</FieldLabel>
+        <Textarea
+          id='descripcion'
+          value={descripcion}
+          onChange={(e) => setDescripcion(e.target.value)}
+          placeholder='Descripción del artista para el catálogo...'
+          className='min-h-32'
+        />
+      </Field>
+
+      <div className='flex items-center justify-center gap-6 py-4'>
+        <div className='flex items-center gap-2'>
+          <Switch checked={destacado} onCheckedChange={setDestacado} />
+          <Label>Destacado</Label>
+        </div>
+        <div className='flex items-center gap-2'>
+          <Switch checked={activo} onCheckedChange={setActivo} />
+          <Label>Activo</Label>
+        </div>
+      </div>
+
+      <div className='flex justify-end gap-2 pt-2'>
+        <Button variant='outline' onClick={onCancel}>
+          Cancelar
+        </Button>
+        <Button onClick={handleApply}>Agregar al catálogo</Button>
+      </div>
+    </FieldGroup>
+  )
+}
+
+export function AddCatalogDialog() {
+  const addCatalogDialogOpen = useCatalogViewStore(
+    (s) => s.addCatalogDialogOpen
+  )
+  const closeAddCatalogDialog = useCatalogViewStore(
+    (s) => s.closeAddCatalogDialog
+  )
+  const add = useCatalogOperationStore((s) => s.add)
+
+  const handleApply = (data: {
+    artistaId: string
+    orden: string
+    destacado: boolean
+    activo: boolean
+    descripcion: string | null
+  }) => {
+    add({
+      ...data,
+      avatarUrl: null,
+      deletedAt: null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString()
+    })
+    closeAddCatalogDialog()
+  }
+
+  return (
+    <EntityFormDialog
+      open={addCatalogDialogOpen}
+      onOpenChange={(open) => !open && closeAddCatalogDialog()}
+      title='Agregar al Catálogo'
+    >
+      {addCatalogDialogOpen && (
+        <AddCatalogFormContent
+          onApply={handleApply}
+          onCancel={closeAddCatalogDialog}
+        />
+      )}
+    </EntityFormDialog>
+  )
+}

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/add-catalog-dialog.tsx
@@ -18,7 +18,6 @@ import {
   FieldGroup,
   FieldLabel
 } from '@/shared/components/ui/field'
-import { Input } from '@/shared/components/ui/input'
 import { Switch } from '@/shared/components/ui/switch'
 import { Textarea } from '@/shared/components/ui/textarea'
 import { Label } from '@/shared/components/ui/label'

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-artists-container.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-artists-container.tsx
@@ -7,13 +7,17 @@ import { useRouteChanges } from '@/shared/hooks/use-route-changes'
 import { RouteSaveToolbar } from '@/shared/components/route-save-toolbar'
 import { CatalogFilters as CatalogFiltersComponent } from './catalog-filters'
 import { EditCatalogDialog } from './edit-catalog-dialog'
+import { AddCatalogDialog } from './add-catalog-dialog'
 import { useCatalogFilterStore } from '../_store/catalog-filter-store'
+import { useCatalogViewStore } from '../_store/catalog-view-store'
 import { useCatalogPaginationStore } from '../_store/catalog-pagination-store'
 import { useCatalogoPush } from '../_hooks/use-catalogo-push'
 import { useArtistaPush } from '../../_hooks/use-artista-push'
 import { toast } from 'sonner'
 import { CatalogTableContainer } from './catalog-table-container'
 import { EditArtistDialog } from './edit-artist-dialog'
+import { Button } from '@/shared/components/ui/button'
+import { Plus } from 'lucide-react'
 
 export function CatalogArtistsContainer() {
   const router = useRouter()
@@ -111,16 +115,23 @@ export function CatalogArtistsContainer() {
     saveArtista()
   }
 
+  const openAddCatalogDialog = useCatalogViewStore((s) => s.openAddCatalogDialog)
+
   return (
     <div className='grid space-y-4'>
       <div className='flex items-center justify-between'>
         <CatalogFiltersComponent onFiltersChange={handleFiltersChange} />
+        <Button size='sm' variant='outline' onClick={openAddCatalogDialog} className='gap-1'>
+          <Plus className='h-4 w-4' />
+          Agregar al catálogo
+        </Button>
       </div>
 
       <CatalogTableContainer handleFiltersChange={handleFiltersChange} />
 
       {/* Dialog Nivel 1: Catálogo */}
       <EditCatalogDialog />
+      <AddCatalogDialog />
 
       {/* Dialog Nivel 2: Artista (stacked) */}
       <EditArtistDialog />

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-content.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_components/catalog-content.tsx
@@ -1,5 +1,4 @@
 import { Suspense } from 'react'
-import { EmptyState } from '@/shared/components/empty-state'
 import { getCatalogData } from '../_lib/get-catalog-data'
 import { CatalogStoreInitialization } from './catalog-store-initialization'
 import { CatalogArtistsContainer } from './catalog-artists-container'
@@ -8,18 +7,9 @@ import { Skeleton } from '@/shared/components/ui/skeleton'
 export async function CatalogContent() {
   const catalog = await getCatalogData()
 
-  if (!catalog || catalog.length === 0) {
-    return (
-      <EmptyState
-        title='No se encontraron artistas'
-        description='No hay artistas que coincidan con los filtros aplicados.'
-      />
-    )
-  }
-
   return (
     <Suspense fallback={<CatalogContentSkeleton />}>
-      <CatalogStoreInitialization initialData={catalog} />
+      <CatalogStoreInitialization initialData={catalog ?? []} />
       <CatalogArtistsContainer />
     </Suspense>
   )

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_schemas/catalogo.schema.ts
@@ -5,8 +5,12 @@ import { artist } from '@frijolmagico/database/schema'
 export const catalogoArtistaInsertSchema = createInsertSchema(
   artist.catalogArtist,
   {
-    artistaId: (s) =>
-      s.int().positive().min(1, { error: 'El artista es obligatorio' }),
+    artistaId: () =>
+      z.coerce
+        .number()
+        .int()
+        .positive()
+        .min(1, { error: 'El artista es obligatorio' }),
     orden: (s) => s.min(1, { error: 'El orden es obligatorio' })
   }
 )

--- a/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_store/catalog-view-store.ts
+++ b/apps/admin/src/app/(authenticated)/(admin)/artistas/catalogo/_store/catalog-view-store.ts
@@ -8,6 +8,7 @@ interface CatalogViewState {
   // Dialog UI State
   catalogDialogOpen: boolean
   artistDialogOpen: boolean
+  addCatalogDialogOpen: boolean
   selectedCatalogId: string | null
 
   // Actions
@@ -20,6 +21,9 @@ interface CatalogViewState {
   openArtistDialog: () => void
   closeArtistDialog: () => void
 
+  openAddCatalogDialog: () => void
+  closeAddCatalogDialog: () => void
+
   closeAllDialogs: () => void
 }
 
@@ -30,6 +34,7 @@ export const useCatalogViewStore = create<CatalogViewState>((set) => ({
 
   catalogDialogOpen: false,
   artistDialogOpen: false,
+  addCatalogDialogOpen: false,
   selectedCatalogId: null,
 
   startDrag: (catalogId) =>
@@ -50,10 +55,14 @@ export const useCatalogViewStore = create<CatalogViewState>((set) => ({
   openArtistDialog: () => set({ artistDialogOpen: true }),
   closeArtistDialog: () => set({ artistDialogOpen: false }),
 
+  openAddCatalogDialog: () => set({ addCatalogDialogOpen: true }),
+  closeAddCatalogDialog: () => set({ addCatalogDialogOpen: false }),
+
   closeAllDialogs: () =>
     set({
       catalogDialogOpen: false,
       artistDialogOpen: false,
+      addCatalogDialogOpen: false,
       selectedCatalogId: null
     })
 }))

--- a/apps/admin/src/app/(authenticated)/(admin)/general/_components/team-row.tsx
+++ b/apps/admin/src/app/(authenticated)/(admin)/general/_components/team-row.tsx
@@ -6,18 +6,11 @@ import {
   useTeamProjectionStore
 } from '../_store/organization-team-ui-store'
 import { cn } from '@/lib/utils'
-import { ButtonWithTooltip } from '@/shared/components/button-with-tooltip'
 import { useTeamDialog } from '../_store/team-dialog-store'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger
-} from '@/shared/components/ui/dropdown-menu'
-import Link from 'next/link'
 import { StateBadge } from '@/shared/components/state-badge'
 import { memo } from 'react'
 import { ActionMenuButton } from '@/shared/components/action-menu-button'
+import { RRSSViewer } from '@/shared/components/rrss-viewer/rrss-viewer'
 
 interface TeamRowProps {
   id: string
@@ -28,10 +21,6 @@ export const TeamRow = memo(function TeamRow({ id }: TeamRowProps) {
   const remove = useTeamOperationStore((s) => s.remove)
   const restore = useTeamOperationStore((s) => s.restore)
   const member = useTeamProjectionStore((s) => s.byId[id])
-
-  const socials = Object.entries(member?.rrss || {}).flatMap(
-    ([platform, urls]) => urls.map((url) => ({ platform, url }))
-  )
 
   if (!member) return null
 
@@ -54,41 +43,7 @@ export const TeamRow = memo(function TeamRow({ id }: TeamRowProps) {
       </TableCell>
       <TableCell>{member.phone || '-'}</TableCell>
       <TableCell>
-        {member.rrss ? (
-          <DropdownMenu>
-            <DropdownMenuTrigger
-              render={
-                <ButtonWithTooltip
-                  size='xs'
-                  variant='outline'
-                  tooltipContent='Ver RRSS'
-                  disabled={member.__meta?.isDeleted}
-                >
-                  Ver
-                </ButtonWithTooltip>
-              }
-            />
-
-            <DropdownMenuContent className='w-full min-w-40'>
-              {socials.map(({ platform, url }) => (
-                <DropdownMenuItem
-                  key={url + platform}
-                  render={
-                    <Link
-                      href={url}
-                      target='_blank'
-                      className='w-full text-nowrap'
-                    >
-                      {platform}: @{url.split('/')[3]}
-                    </Link>
-                  }
-                />
-              ))}
-            </DropdownMenuContent>
-          </DropdownMenu>
-        ) : (
-          '-'
-        )}
+        <RRSSViewer rrss={member.rrss} disabled={member.__meta?.isDeleted} />
       </TableCell>
 
       <TableCell>

--- a/apps/admin/src/shared/components/artist-form/artist-form.tsx
+++ b/apps/admin/src/shared/components/artist-form/artist-form.tsx
@@ -1,0 +1,126 @@
+'use client'
+
+import { Input } from '@/shared/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue
+} from '@/shared/components/ui/select'
+import {
+  Field,
+  FieldGroup,
+  FieldLabel,
+  FieldError
+} from '@/shared/components/ui/field'
+
+interface ArtistFormLayoutProps {
+  formData: {
+    nombre: string
+    pseudonimo: string
+    correo: string
+    estadoId: string | number
+    ciudad: string
+    pais: string
+  }
+  errors?: { pseudonimo?: string; estadoId?: string }
+  onFieldChange: (field: string, value: string) => void
+  customFields?: React.ReactNode
+  actions?: React.ReactNode
+}
+
+export function ArtistFormLayout({
+  formData,
+  errors,
+  onFieldChange,
+  customFields,
+  actions
+}: ArtistFormLayoutProps) {
+  return (
+    <FieldGroup>
+      <Field>
+        <FieldLabel htmlFor='pseudonimo'>
+          Pseudónimo <span className='text-destructive'>*</span>
+        </FieldLabel>
+        <Input
+          id='pseudonimo'
+          value={formData.pseudonimo || ''}
+          onChange={(e) => onFieldChange('pseudonimo', e.target.value)}
+          placeholder='@usuario'
+          aria-invalid={!!errors?.pseudonimo}
+        />
+        {errors?.pseudonimo && (
+          <FieldError>{errors.pseudonimo}</FieldError>
+        )}
+      </Field>
+
+      {customFields}
+
+      <Field>
+        <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
+        <Input
+          id='nombre'
+          value={formData.nombre}
+          onChange={(e) => onFieldChange('nombre', e.target.value)}
+          placeholder='Nombre completo'
+        />
+      </Field>
+
+      <div className='grid grid-cols-2 gap-4'>
+        <Field>
+          <FieldLabel htmlFor='correo'>Correo electrónico</FieldLabel>
+          <Input
+            id='correo'
+            type='email'
+            value={formData.correo}
+            onChange={(e) => onFieldChange('correo', e.target.value)}
+            placeholder='artista@ejemplo.com'
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor='estadoId'>Estado</FieldLabel>
+          <Select
+            value={String(formData.estadoId)}
+            onValueChange={(val) => onFieldChange('estadoId', val || '1')}
+          >
+            <SelectTrigger id='estadoId'>
+              <SelectValue placeholder='Estado' />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value='2'>Activo</SelectItem>
+              <SelectItem value='3'>Inactivo</SelectItem>
+              <SelectItem value='4'>Vetado</SelectItem>
+              <SelectItem value='5'>Cancelado</SelectItem>
+              <SelectItem value='1'>Desconocido</SelectItem>
+            </SelectContent>
+          </Select>
+          {errors?.estadoId && <FieldError>{errors.estadoId}</FieldError>}
+        </Field>
+      </div>
+
+      <div className='grid grid-cols-2 gap-4'>
+        <Field>
+          <FieldLabel htmlFor='ciudad'>Ciudad</FieldLabel>
+          <Input
+            id='ciudad'
+            value={formData.ciudad || ''}
+            onChange={(e) => onFieldChange('ciudad', e.target.value)}
+            placeholder='Santiago'
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor='pais'>País</FieldLabel>
+          <Input
+            id='pais'
+            value={formData.pais || ''}
+            onChange={(e) => onFieldChange('pais', e.target.value)}
+            placeholder='Chile'
+          />
+        </Field>
+      </div>
+
+      {actions}
+    </FieldGroup>
+  )
+}

--- a/apps/admin/src/shared/components/artist-form/artist-form.tsx
+++ b/apps/admin/src/shared/components/artist-form/artist-form.tsx
@@ -19,6 +19,8 @@ interface ArtistFormLayoutProps {
   formData: {
     nombre: string
     pseudonimo: string
+    rut: string
+    telefono: string
     correo: string
     estadoId: string | number
     ciudad: string
@@ -40,6 +42,16 @@ export function ArtistFormLayout({
   return (
     <FieldGroup>
       <Field>
+        <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
+        <Input
+          id='nombre'
+          value={formData.nombre}
+          onChange={(e) => onFieldChange('nombre', e.target.value)}
+          placeholder='Nombre completo'
+        />
+      </Field>
+
+      <Field>
         <FieldLabel htmlFor='pseudonimo'>
           Pseudónimo <span className='text-destructive'>*</span>
         </FieldLabel>
@@ -57,15 +69,26 @@ export function ArtistFormLayout({
 
       {customFields}
 
-      <Field>
-        <FieldLabel htmlFor='nombre'>Nombre</FieldLabel>
-        <Input
-          id='nombre'
-          value={formData.nombre}
-          onChange={(e) => onFieldChange('nombre', e.target.value)}
-          placeholder='Nombre completo'
-        />
-      </Field>
+      <div className='grid grid-cols-2 gap-4'>
+        <Field>
+          <FieldLabel htmlFor='rut'>RUT</FieldLabel>
+          <Input
+            id='rut'
+            value={formData.rut || ''}
+            onChange={(e) => onFieldChange('rut', e.target.value)}
+            placeholder='12.345.678-9'
+          />
+        </Field>
+        <Field>
+          <FieldLabel htmlFor='telefono'>Teléfono</FieldLabel>
+          <Input
+            id='telefono'
+            value={formData.telefono || ''}
+            onChange={(e) => onFieldChange('telefono', e.target.value)}
+            placeholder='+56912345678'
+          />
+        </Field>
+      </div>
 
       <div className='grid grid-cols-2 gap-4'>
         <Field>

--- a/apps/admin/src/shared/components/rrss-viewer/rrss-viewer.tsx
+++ b/apps/admin/src/shared/components/rrss-viewer/rrss-viewer.tsx
@@ -1,6 +1,5 @@
 'use client'
 
-import Link from 'next/link'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -12,6 +11,26 @@ import { ButtonWithTooltip } from '@/shared/components/button-with-tooltip'
 interface RRSSViewerProps {
   rrss: Record<string, string | string[]> | null
   disabled?: boolean
+}
+
+function extractHandle(url: string): string {
+  try {
+    const parsed = new URL(url)
+    const segments = parsed.pathname.split('/').filter(Boolean)
+    return segments[segments.length - 1] || url
+  } catch {
+    return url
+  }
+}
+
+function isValidUrl(url: string): boolean {
+  if (!url) return false
+  try {
+    const parsed = new URL(url)
+    return parsed.protocol === 'http:' || parsed.protocol === 'https:'
+  } catch {
+    return false
+  }
 }
 
 export function RRSSViewer({ rrss, disabled }: RRSSViewerProps) {
@@ -27,7 +46,9 @@ export function RRSSViewer({ rrss, disabled }: RRSSViewerProps) {
       : [{ platform, url: value }]
   )
 
-  if (flat.length === 0) {
+  const validEntries = flat.filter(({ url }) => isValidUrl(url))
+
+  if (validEntries.length === 0) {
     return <span className='text-muted-foreground'>-</span>
   }
 
@@ -47,17 +68,18 @@ export function RRSSViewer({ rrss, disabled }: RRSSViewerProps) {
       />
 
       <DropdownMenuContent className='w-full min-w-40'>
-        {flat.map(({ platform, url }) => (
+        {validEntries.map(({ platform, url }, index) => (
           <DropdownMenuItem
-            key={url + platform}
+            key={`${platform}-${url}-${index}`}
             render={
-              <Link
+              <a
                 href={url}
                 target='_blank'
+                rel='noopener noreferrer'
                 className='w-full text-nowrap'
               >
-                {platform}: @{url.split('/')[3]}
-              </Link>
+                {platform}: @{extractHandle(url)}
+              </a>
             }
           />
         ))}

--- a/apps/admin/src/shared/components/rrss-viewer/rrss-viewer.tsx
+++ b/apps/admin/src/shared/components/rrss-viewer/rrss-viewer.tsx
@@ -1,0 +1,67 @@
+'use client'
+
+import Link from 'next/link'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/shared/components/ui/dropdown-menu'
+import { ButtonWithTooltip } from '@/shared/components/button-with-tooltip'
+
+interface RRSSViewerProps {
+  rrss: Record<string, string | string[]> | null
+  disabled?: boolean
+}
+
+export function RRSSViewer({ rrss, disabled }: RRSSViewerProps) {
+  if (!rrss || Object.keys(rrss).length === 0) {
+    return <span className='text-muted-foreground'>-</span>
+  }
+
+  // Normalize both shapes to flat { platform, url }[] array
+  const entries = Object.entries(rrss)
+  const flat = entries.flatMap(([platform, value]) =>
+    Array.isArray(value)
+      ? value.map((url) => ({ platform, url }))
+      : [{ platform, url: value }]
+  )
+
+  if (flat.length === 0) {
+    return <span className='text-muted-foreground'>-</span>
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <ButtonWithTooltip
+            size='xs'
+            variant='outline'
+            tooltipContent='Ver RRSS'
+            disabled={disabled}
+          >
+            Ver
+          </ButtonWithTooltip>
+        }
+      />
+
+      <DropdownMenuContent className='w-full min-w-40'>
+        {flat.map(({ platform, url }) => (
+          <DropdownMenuItem
+            key={url + platform}
+            render={
+              <Link
+                href={url}
+                target='_blank'
+                className='w-full text-nowrap'
+              >
+                {platform}: @{url.split('/')[3]}
+              </Link>
+            }
+          />
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

- Add dedicated add artist dialog (`AddArtistDialog`) with full form fields
- Add dedicated add catalog dialog (`AddCatalogDialog`) with artist selection
- Extract shared `ArtistFormLayout` component for consistent form layout
- Extract shared `RRSSViewer` component for displaying social media links
- Refactor edit dialog to use shared layout component
- Fix catalog empty state initialization
- Fix artistaId coercion in catalogo insert schema