### PR TITLE
feat(web): add view transitions for artist detail pages

### DIFF
--- a/apps/web/src/app/(sections)/catalogo/[slug]/page.tsx
+++ b/apps/web/src/app/(sections)/catalogo/[slug]/page.tsx
@@ -12,6 +12,8 @@ import { ArtistCollectiveGrid } from './components/ArtistCollectiveGrid'
 import { RelatedArtists } from './components/RelatedArtists'
 import { TrackPageView } from '@/components/analytics/TrackPageView'
 import { SectionHomeButton } from '@/components/SectionsHomeButton'
+import { ArtistAvatarTransition } from '@/components/transitions/ArtistAvatarTransition'
+import { ArtistNameTransition } from '@/components/transitions/ArtistNameTransition'
 
 // Generate params for all artist pages at build time
 export async function generateStaticParams() {
@@ -85,23 +87,27 @@ export default async function ArtistPage({
 
         <div className='flex flex-col gap-8 md:flex-row'>
           <aside className='md:sticky md:top-24 md:self-start'>
-            <figure className='relative size-64 shrink-0 md:size-100'>
-              <Image
-                src={artist.avatar}
-                alt={`Imagen de ${artist.name}`}
-                fill
-                className='border-primary rounded-xl border-2 object-cover shadow-xl'
-                priority
-                sizes='(max-width: 768px) 256px, 320px'
-              />
-            </figure>
+            <ArtistAvatarTransition slug={slug}>
+              <figure className='relative size-64 shrink-0 md:size-100'>
+                <Image
+                  src={artist.avatar}
+                  alt={`Imagen de ${artist.name}`}
+                  fill
+                  className='border-primary rounded-xl border-2 object-cover shadow-xl'
+                  priority
+                  sizes='(max-width: 768px) 256px, 320px'
+                />
+              </figure>
+            </ArtistAvatarTransition>
           </aside>
 
           <div className='min-w-0 flex-1 space-y-8'>
             <header>
-              <h1 className='text-primary text-4xl leading-none font-bold md:text-6xl'>
-                {artist.name}
-              </h1>
+              <ArtistNameTransition slug={slug}>
+                <h1 className='text-primary text-4xl leading-none font-bold md:text-6xl'>
+                  {artist.name}
+                </h1>
+              </ArtistNameTransition>
               <p className='text-foreground/70 text-lg'>
                 {artist.city}
                 {artist.country ? `, ${artist.country}` : ''}

--- a/apps/web/src/app/(sections)/catalogo/components/CatalogArtistPanelContent.tsx
+++ b/apps/web/src/app/(sections)/catalogo/components/CatalogArtistPanelContent.tsx
@@ -3,6 +3,8 @@ import { Mail } from 'lucide-react'
 import { Instagram } from '@/components/icons/Instagram'
 import Markdown from 'react-markdown'
 
+import { ArtistAvatarTransition } from '@/components/transitions/ArtistAvatarTransition'
+import { ArtistNameTransition } from '@/components/transitions/ArtistNameTransition'
 import { CollectiveMemberLink } from './CollectiveMemberLink'
 import { getInstagramUserTag } from '@frijolmagico/utils/string'
 
@@ -87,19 +89,23 @@ export const CatalogArtistPanelContent = ({
     <article className='space-y-6'>
       {/* Avatar + Name + Location + Category */}
       <section className='flex items-center space-x-4'>
-        <figure className='relative h-20 w-20 shrink-0'>
-          <Image
-            src={artist.avatar}
-            alt={`Imagen de ${artist.name}`}
-            fill
-            sizes='80px'
-            className='border-primary rounded-full border-2 object-cover'
-          />
-        </figure>
+        <ArtistAvatarTransition slug={artist.slug ?? ''}>
+          <figure className='relative h-20 w-20 shrink-0'>
+            <Image
+              src={artist.avatar}
+              alt={`Imagen de ${artist.name}`}
+              fill
+              sizes='80px'
+              className='border-primary rounded-full border-2 object-cover'
+            />
+          </figure>
+        </ArtistAvatarTransition>
         <div>
-          <h3 className='text-secondary text-2xl leading-none font-bold'>
-            {artist.name}
-          </h3>
+          <ArtistNameTransition slug={artist.slug ?? ''}>
+            <h3 className='text-secondary text-2xl leading-none font-bold'>
+              {artist.name}
+            </h3>
+          </ArtistNameTransition>
           <p className='text-sm text-gray-600'>
             {artist.city} - {artist.country}
           </p>

--- a/apps/web/src/app/(sections)/catalogo/components/CatalogPanel.tsx
+++ b/apps/web/src/app/(sections)/catalogo/components/CatalogPanel.tsx
@@ -123,6 +123,7 @@ export const CatalogPanel = ({
             <div className='border-border/20 bg-background sticky bottom-0 mt-6 border-t pt-4'>
               <Link
                 href={`/catalogo/${selectedArtist.slug}`}
+                transitionTypes={['artist-detail']}
                 aria-label={`Ver perfil completo de ${selectedArtist.name}`}
                 className='bg-primary text-background hover:bg-primary/90 block w-full cursor-pointer rounded-lg px-4 py-3 text-center text-sm font-semibold transition-colors'
               >

--- a/apps/web/src/components/ArtistCard.tsx
+++ b/apps/web/src/components/ArtistCard.tsx
@@ -3,6 +3,9 @@ import { ArrowRight, StarIcon } from 'lucide-react'
 import Link from 'next/link'
 import Image from 'next/image'
 
+import { ArtistAvatarTransition } from '@/components/transitions/ArtistAvatarTransition'
+import { ArtistNameTransition } from '@/components/transitions/ArtistNameTransition'
+
 interface ArtistCardProps {
   artist: {
     pseudonimo: string
@@ -15,12 +18,15 @@ interface ArtistCardProps {
 export function ArtistCard({ artist, isFeatured }: ArtistCardProps) {
   return (
     <div className='relative'>
-      <h3 className='font-roboto-mono text-primary ml-2 text-lg font-bold'>
-        {artist.pseudonimo}
-      </h3>
+      <ArtistNameTransition slug={artist.slug ?? ''}>
+        <h3 className='font-roboto-mono text-primary ml-2 text-lg font-bold'>
+          {artist.pseudonimo}
+        </h3>
+      </ArtistNameTransition>
       <Link
         aria-label={`Ver perfil de ${artist.pseudonimo}`}
         href={artist.slug ? `/catalogo/${artist.slug}` : '#'}
+        transitionTypes={['artist-detail']}
         className='before:bg-primary group relative block size-50'
       >
         {isFeatured && (
@@ -28,13 +34,15 @@ export function ArtistCard({ artist, isFeatured }: ArtistCardProps) {
         )}
         <div className='bg-primary absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg duration-300 group-hover:translate-0'></div>
         <div className='border-primary group relative overflow-hidden rounded-lg border-2'>
-          <Image
-            src={getAvatarUrl(artist.imagen_url)}
-            alt={`${artist.pseudonimo} avatar`}
-            width={200}
-            height={200}
-            className='size-full origin-center object-cover duration-300 group-hover:scale-110'
-          />
+          <ArtistAvatarTransition slug={artist.slug ?? ''}>
+            <Image
+              src={getAvatarUrl(artist.imagen_url)}
+              alt={`${artist.pseudonimo} avatar`}
+              width={200}
+              height={200}
+              className='size-full origin-center object-cover duration-300 group-hover:scale-110'
+            />
+          </ArtistAvatarTransition>
           <span className='bg-primary text-background absolute top-0 right-0 bottom-0 left-0 m-auto flex size-fit items-center justify-center gap-2 rounded-md border px-2 py-2 leading-none opacity-0 duration-150 group-hover:opacity-100'>
             Ver más <ArrowRight className='size-4' />
           </span>

--- a/apps/web/src/components/transitions/ArtistAvatarTransition.tsx
+++ b/apps/web/src/components/transitions/ArtistAvatarTransition.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { ViewTransition } from 'react'
+
+import type { ReactNode } from 'react'
+
+interface ArtistAvatarTransitionProps {
+  slug: string
+  children: ReactNode
+  className?: string
+}
+
+export function ArtistAvatarTransition({
+  slug,
+  children
+}: ArtistAvatarTransitionProps) {
+  if (!slug) return <>{children}</>
+
+  return (
+    <ViewTransition name={`artist-avatar-${slug}`}>{children}</ViewTransition>
+  )
+}

--- a/apps/web/src/components/transitions/ArtistNameTransition.tsx
+++ b/apps/web/src/components/transitions/ArtistNameTransition.tsx
@@ -1,0 +1,22 @@
+'use client'
+
+import { ViewTransition } from 'react'
+
+import type { ReactNode } from 'react'
+
+interface ArtistNameTransitionProps {
+  slug: string
+  children: ReactNode
+  className?: string
+}
+
+export function ArtistNameTransition({
+  slug,
+  children
+}: ArtistNameTransitionProps) {
+  if (!slug) return <>{children}</>
+
+  return (
+    <ViewTransition name={`artist-name-${slug}`}>{children}</ViewTransition>
+  )
+}


### PR DESCRIPTION
## Summary

Adds browser-native shared-element View Transitions when navigating to artist detail pages (`/catalogo/[slug]`) from three entry points: home FeaturedArtists, catalog panel "Perfil completo", and RelatedArtists.

Only the avatar image and artist name morph — the rest of the page uses default cross-fade.

## How it works

Two tiny `'use client'` wrapper components (`ArtistAvatarTransition`, `ArtistNameTransition`) wrap avatar and name elements with React's `<ViewTransition>` using slug-based names (`artist-avatar-{slug}`, `artist-name-{slug}`). Source `<Link>` components opt in via `transitionTypes={['artist-detail']}`.

Next.js 16 auto-wraps route navigations with `startViewTransition` when `experimental.viewTransition: true` (already enabled).

## Changes

| File | Change |
|------|--------|
| `src/components/transitions/ArtistAvatarTransition.tsx` | Created — client wrapper for avatar morph |
| `src/components/transitions/ArtistNameTransition.tsx` | Created — client wrapper for name morph |
| `src/components/ArtistCard.tsx` | Modified — wrapped avatar + name, added `transitionTypes` |
| `catalogo/[slug]/page.tsx` | Modified — wrapped detail avatar + name |
| `CatalogPanel.tsx` | Modified — added `transitionTypes` to "Perfil completo" link |
| `CatalogArtistPanelContent.tsx` | Modified — wrapped panel avatar + name |

## What's NOT included

- Backwards transitions (dropped — requires fragile directional tracking)
- Panel open/close animations
- Catalog grid card-to-card transitions
- No custom CSS needed (browser defaults handle cross-fade)

## Test Plan

- [x] TypeScript type-check passes
- [x] ESLint clean on changed files
- [x] Manual verification: home → detail, panel → detail, detail → detail morphs work