### PR TITLE
fix(admin): fix modoIngresoId Select type mismatch in activity dialogs

### DIFF
--- a/apps/admin/src/app/(core)/eventos/participaciones/_components/create-activity-dialog.tsx
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_components/create-activity-dialog.tsx
@@ -335,8 +335,8 @@ export function CreateActivityDialog({
               control={methods.control}
               render={({ field }) => (
                 <Select
-                  value={field.value}
-                  onValueChange={(val) => field.onChange(val)}
+                  value={String(field.value ?? '')}
+                  onValueChange={(val) => field.onChange(Number(val))}
                   disabled={isSubmitting}
                 >
                   <SelectTrigger>

--- a/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
@@ -297,8 +297,8 @@ export function UpdateActivityDialog({ edition }: UpdateActivityDialogProps) {
               control={methods.control}
               render={({ field }) => (
                 <Select
-                  value={field.value}
-                  onValueChange={(val) => field.onChange(val)}
+                  value={String(field.value ?? '')}
+                  onValueChange={(val) => field.onChange(Number(val))}
                   disabled={isSubmitting}
                 >
                   <SelectTrigger>
@@ -453,19 +453,6 @@ export function UpdateActivityDialog({ edition }: UpdateActivityDialogProps) {
             )}
           </Field>
 
-          <Field>
-            <FieldLabel htmlFor={`activity-notes-${activity.id}`}>
-              Notas
-            </FieldLabel>
-            <Textarea
-              id={`activity-notes-${activity.id}`}
-              {...methods.register('notas')}
-              disabled={isSubmitting}
-              rows={2}
-              placeholder='Notas...'
-            />
-            {errors.notas && <FieldError>{errors.notas.message}</FieldError>}
-          </Field>
         </FieldGroup>
       </form>
     </EntityFormDialog>


### PR DESCRIPTION
## Problem

The `modoIngresoId` `Select` in `CreateActivityDialog` and `UpdateActivityDialog` was passing a `number` to Radix UI Select's `value` prop and receiving a `string` from `onValueChange` without type conversion. This caused:

1. The Select to not display the currently selected value (Radix compares `number !== string`)
2. Zod validation to fail after any user interaction with the field (`z.number().int().positive()` rejects strings)
3. The submit button to become permanently disabled due to `!isValid`

## Fix

Changed both dialogs to use the pattern already present in the exhibition dialogs:

```tsx
// Before (broken)
value={field.value}
onValueChange={(val) => field.onChange(val)}

// After (fixed)
value={String(field.value ?? '')}
onValueChange={(val) => field.onChange(Number(val))}
```

Also removed a duplicate `notas` field registration in `UpdateActivityDialog` that was causing react-hook-form to register the same form field twice.

## Files changed

- `apps/admin/.../create-activity-dialog.tsx` — fix modoIngresoId Select
- `apps/admin/.../update-activity-dialog.tsx` — fix modoIngresoId Select + remove duplicate notas

## Verification

- TypeScript type-check: ✅ passed
- ESLint: ✅ 0 new errors