### PR TITLE
feat(festivales): FestivalNavigator, Ver más button, and timeline UI improvements

### DIFF
--- a/apps/web/bunfig.toml
+++ b/apps/web/bunfig.toml
@@ -1,2 +1,3 @@
 [test]
 preload = ["./test-setup.ts"]
+isolate = true

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/adjacentFestivalsRepository.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/adjacentFestivalsRepository.ts
@@ -1,0 +1,71 @@
+import { executeQuery } from '@frijolmagico/database/client'
+import { getDataSource } from '@/infra/config/dataSourceConfig'
+
+import { ADJACENT_FESTIVALS_QUERY } from './queries/adjacentFestivalsQuery'
+
+export interface AdjacentFestivalRow {
+  direction: string
+  slug: string
+  numero_edicion: string
+  edicion_nombre: string | null
+  evento_nombre: string
+}
+
+export interface AdjacentFestival {
+  slug: string
+  numero_edicion: string
+  edicion_nombre: string | null
+  evento_nombre: string
+}
+
+export interface AdjacentFestivalsResult {
+  prev: AdjacentFestival | null
+  next: AdjacentFestival | null
+}
+
+export async function adjacentFestivalsRepository(
+  slug: string
+): Promise<AdjacentFestivalsResult> {
+  if (!slug.trim()) {
+    return { prev: null, next: null }
+  }
+
+  const source = getDataSource({ prod: 'database' })
+
+  if (source === 'local' || source === 'database') {
+    const { data, error } = await executeQuery<AdjacentFestivalRow>(
+      ADJACENT_FESTIVALS_QUERY,
+      [slug]
+    )
+
+    if (!error && data && data.length > 0) {
+      const prevRow = data.find((r) => r.direction === 'prev')
+      const nextRow = data.find((r) => r.direction === 'next')
+
+      return {
+        prev: prevRow
+          ? {
+              slug: prevRow.slug,
+              numero_edicion: prevRow.numero_edicion,
+              edicion_nombre: prevRow.edicion_nombre,
+              evento_nombre: prevRow.evento_nombre
+            }
+          : null,
+        next: nextRow
+          ? {
+              slug: nextRow.slug,
+              numero_edicion: nextRow.numero_edicion,
+              edicion_nombre: nextRow.edicion_nombre,
+              evento_nombre: nextRow.evento_nombre
+            }
+          : null
+      }
+    }
+
+    console.warn(
+      '⚠️ Database query failed for adjacent festivals, returning empty'
+    )
+  }
+
+  return { prev: null, next: null }
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/festivalDetailRepository.test.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/festivalDetailRepository.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { executeQueryMock } from '@/test-utils/mockDatabase'
+
+import { festivalDetailRepository } from './festivalDetailRepository'
+
+beforeEach(() => {
+  executeQueryMock.mockReset()
+})
+
+const baseRawResult = {
+  resultado: JSON.stringify({
+    edition_id: 10,
+    slug: 'edicion-15-1',
+    evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+    edicion_nombre: 'Edición XV',
+    numero_edicion: 'XV',
+    poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+    dias: [],
+    participantes: [
+      {
+        pseudonimo: 'Artista Ejemplo',
+        disciplina_slug: 'ilustracion',
+        catalogo_slug: 'artista-ejemplo'
+      }
+    ],
+    actividades: []
+  })
+}
+
+describe('festivalDetailRepository', () => {
+  test('returns null when slug is empty', async () => {
+    const result = await festivalDetailRepository('')
+
+    expect(result).toBeNull()
+    expect(executeQueryMock).not.toHaveBeenCalled()
+  })
+
+  test('returns mapped detail when query returns a row', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [baseRawResult],
+      error: null
+    })
+
+    const result = await festivalDetailRepository('edicion-15-1')
+
+    expect(result).not.toBeNull()
+    expect(result?.slug).toBe('edicion-15-1')
+    expect(result?.participantes[0].disciplina_slug).toBe('Ilustración')
+  })
+
+  test('returns null when no rows match', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [],
+      error: null
+    })
+
+    const result = await festivalDetailRepository('edicion-999-999')
+
+    expect(result).toBeNull()
+  })
+
+  test('returns null and logs error when query fails', async () => {
+    const consoleSpy = mock((..._args: unknown[]) => {})
+    globalThis.console.warn = consoleSpy
+
+    executeQueryMock.mockResolvedValueOnce({
+      data: [],
+      error: new Error('DB error')
+    })
+
+    const result = await festivalDetailRepository('edicion-15-1')
+
+    expect(result).toBeNull()
+    expect(consoleSpy).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/festivalDetailRepository.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/festivalDetailRepository.ts
@@ -1,0 +1,39 @@
+import { executeQuery } from '@frijolmagico/database/client'
+import { getDataSource } from '@/infra/config/dataSourceConfig'
+
+import { mapFestivalDetail } from './mappers/festivalDetailMapper'
+import { FESTIVAL_DETAIL_QUERY } from './queries/festivalDetailQuery'
+import { getFestivalDetailMock } from './mocks/festivalDetailData.mock'
+
+import type { FestivalDetail, RawFestivalDetail } from '../../types/festival'
+
+export async function festivalDetailRepository(
+  slug: string
+): Promise<FestivalDetail | null> {
+  if (!slug.trim()) {
+    return null
+  }
+
+  const source = getDataSource({ prod: 'database' })
+
+  if (source === 'local' || source === 'database') {
+    const { data, error } = await executeQuery<RawFestivalDetail>(
+      FESTIVAL_DETAIL_QUERY,
+      [slug]
+    )
+
+    if (!error && data && data.length > 0) {
+      const raw = JSON.parse(data[0].resultado) as FestivalDetail
+
+      if (raw.slug) {
+        return mapFestivalDetail(raw)
+      }
+    }
+
+    console.warn(
+      '⚠️ Database query failed for festival detail, falling back to mock data'
+    )
+  }
+
+  return getFestivalDetailMock(slug) ?? null
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/mappers/festivalDetailMapper.test.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/mappers/festivalDetailMapper.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from 'bun:test'
+
+import { mapFestivalDetail } from './festivalDetailMapper'
+
+import type { FestivalDetail } from '../../../types/festival'
+
+const baseRaw = {
+  edition_id: 10,
+  slug: 'edicion-15-1',
+  evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+  edicion_nombre: 'Edición XV',
+  numero_edicion: 'XV',
+  poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+  dias: [
+    {
+      fecha: '2025-10-03',
+      hora_inicio: '11:00',
+      hora_fin: '20:00',
+      modalidad: 'presencial',
+      lugar: { nombre: 'Casa ULS', direccion: 'Av. Solari 1301' }
+    }
+  ],
+  participantes: [
+    {
+      pseudonimo: 'Artista Ejemplo',
+      disciplina_slug: 'ilustracion',
+      catalogo_slug: 'artista-ejemplo'
+    },
+    {
+      pseudonimo: 'Colectivo X',
+      disciplina_slug: 'manualidades',
+      catalogo_slug: null
+    }
+  ],
+  actividades: [
+    {
+      titulo: 'Taller',
+      descripcion: 'Taller de prueba',
+      duracion_minutos: 60,
+      ubicacion: 'Sala A',
+      hora_inicio: '18:00',
+      tipo: 'taller',
+      fecha: '2025-10-03',
+      participante_pseudonimo: 'Artista Ejemplo'
+    }
+  ]
+}
+
+describe('mapFestivalDetail', () => {
+  test('maps known discipline slugs to labels', () => {
+    const result = mapFestivalDetail(baseRaw as unknown as FestivalDetail)
+
+    expect(result.participantes[0].disciplina_slug).toBe('Ilustración')
+    expect(result.participantes[1].disciplina_slug).toBe('Manualidades')
+  })
+
+  test('keeps unknown discipline slugs when label is missing', () => {
+    const raw = {
+      ...baseRaw,
+      participantes: [
+        {
+          pseudonimo: 'Nuevo Artista',
+          disciplina_slug: 'nueva-disciplina',
+          catalogo_slug: null
+        }
+      ]
+    }
+
+    const result = mapFestivalDetail(raw as unknown as FestivalDetail)
+
+    expect(result.participantes[0].disciplina_slug).toBe('nueva-disciplina')
+  })
+
+  test('returns the same top-level fields', () => {
+    const result = mapFestivalDetail(baseRaw as unknown as FestivalDetail)
+
+    expect(result.edition_id).toBe(10)
+    expect(result.slug).toBe('edicion-15-1')
+    expect(result.evento.nombre).toBe('Festival Frijol Mágico')
+    expect(result.dias).toHaveLength(1)
+    expect(result.actividades).toHaveLength(1)
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/mappers/festivalDetailMapper.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/mappers/festivalDetailMapper.ts
@@ -1,0 +1,27 @@
+import { getDisciplineLabel } from '@/app/(sections)/adapters/mappers/disciplineMapper'
+
+import type { FestivalDetail, FestivalParticipant } from '../../../types/festival'
+
+const mapParticipant = (
+  participant: FestivalParticipant
+): FestivalParticipant => {
+  let disciplinaLabel: string
+
+  try {
+    disciplinaLabel = getDisciplineLabel(participant.disciplina_slug)
+  } catch {
+    disciplinaLabel = participant.disciplina_slug
+  }
+
+  return {
+    ...participant,
+    disciplina_slug: disciplinaLabel
+  }
+}
+
+export const mapFestivalDetail = (raw: FestivalDetail): FestivalDetail => {
+  return {
+    ...raw,
+    participantes: raw.participantes.map(mapParticipant)
+  }
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/mocks/festivalDetailData.mock.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/mocks/festivalDetailData.mock.ts
@@ -1,0 +1,136 @@
+import type { FestivalDetail } from '../../../types/festival'
+
+const mockDetails: Record<string, FestivalDetail> = {
+  'edicion-xv-1': {
+    edition_id: 15,
+    slug: 'edicion-xv-1',
+    evento: {
+      nombre: 'Festival Frijol Mágico',
+      slug: 'frijol-magico'
+    },
+    edicion_nombre: 'Un Nuevo Germinar',
+    numero_edicion: 'XV',
+    poster_url:
+      'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xv.webp',
+    dias: [
+      {
+        fecha: '2025-10-03',
+        hora_inicio: '11:00',
+        hora_fin: '20:00',
+        modalidad: 'presencial',
+        lugar: {
+          nombre: 'Casa Editorial ULS',
+          direccion: 'Av. Alberto Solari 1301, La Serena'
+        }
+      },
+      {
+        fecha: '2025-10-04',
+        hora_inicio: '11:00',
+        hora_fin: '20:00',
+        modalidad: 'presencial',
+        lugar: {
+          nombre: 'Casa Editorial ULS',
+          direccion: 'Av. Alberto Solari 1301, La Serena'
+        }
+      }
+    ],
+    participantes: [
+      {
+        pseudonimo: 'Akane Ilustración',
+        disciplina_slug: 'ilustracion',
+        catalogo_slug: 'akane-ilustracion'
+      },
+      {
+        pseudonimo: 'Sol Dibujante',
+        disciplina_slug: 'ilustracion',
+        catalogo_slug: 'sol-dibujante'
+      },
+      {
+        pseudonimo: 'Manos Que Tejen',
+        disciplina_slug: 'manualidades',
+        catalogo_slug: null
+      },
+      {
+        pseudonimo: 'Cósmica Cómics',
+        disciplina_slug: 'narrativa-grafica',
+        catalogo_slug: 'cosmica-comics'
+      }
+    ],
+    actividades: [
+      {
+        titulo: 'Taller de Acuarela',
+        descripcion: 'Aprende técnicas básicas de acuarela',
+        duracion_minutos: 90,
+        ubicacion: 'Sala 1',
+        hora_inicio: '14:00',
+        tipo: 'taller',
+        fecha: '2025-10-03',
+        participante_pseudonimo: 'Akane Ilustración'
+      },
+      {
+        titulo: 'Concierto de Cierre',
+        descripcion: 'Presentación musical en vivo',
+        duracion_minutos: 60,
+        ubicacion: 'Escenario Principal',
+        hora_inicio: '18:00',
+        tipo: 'musica',
+        fecha: '2025-10-04',
+        participante_pseudonimo: 'Banda Invitada'
+      }
+    ]
+  },
+  'edicion-3-2': {
+    edition_id: 3,
+    slug: 'edicion-3-2',
+    evento: {
+      nombre: 'Ilustradores en Benders',
+      slug: 'ilustra-benders'
+    },
+    edicion_nombre: 'Season 3',
+    numero_edicion: '3',
+    poster_url:
+      'https://cdn.frijolmagico.cl/festivales/ilustra-benders/afiche-3.webp',
+    dias: [
+      {
+        fecha: '2025-05-10',
+        hora_inicio: '19:00',
+        hora_fin: '23:00',
+        modalidad: 'presencial',
+        lugar: {
+          nombre: 'Benders Bar',
+          direccion: 'Av. del Mar 2100, La Serena'
+        }
+      }
+    ],
+    participantes: [
+      {
+        pseudonimo: 'Líneas Nocturnas',
+        disciplina_slug: 'ilustracion',
+        catalogo_slug: 'lineas-nocturnas'
+      },
+      {
+        pseudonimo: 'Trazo Suelto',
+        disciplina_slug: 'ilustracion',
+        catalogo_slug: null
+      }
+    ],
+    actividades: [
+      {
+        titulo: 'Live Drawing Session',
+        descripcion: 'Sesión de dibujo en vivo con música',
+        duracion_minutos: 120,
+        ubicacion: 'Benders Bar',
+        hora_inicio: '20:00',
+        tipo: 'exposicion',
+        fecha: '2025-05-10',
+        participante_pseudonimo: 'Líneas Nocturnas'
+      }
+    ]
+  }
+}
+
+export function getFestivalDetailMock(
+  slug: string
+): FestivalDetail | undefined {
+  return mockDetails[slug]
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/adjacentFestivalsQuery.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/adjacentFestivalsQuery.ts
@@ -1,0 +1,24 @@
+export const ADJACENT_FESTIVALS_QUERY = `
+WITH edition_ranked AS (
+  SELECT
+    ee.slug,
+    ee.numero_edicion,
+    ee.nombre AS edicion_nombre,
+    e.nombre AS evento_nombre,
+    ROW_NUMBER() OVER (ORDER BY MIN(eed.fecha) ASC) AS pos
+  FROM evento_edicion ee
+  JOIN evento e ON e.id = ee.evento_id
+  JOIN evento_edicion_dia eed ON eed.evento_edicion_id = ee.id
+  GROUP BY ee.id
+),
+current_pos AS (
+  SELECT pos FROM edition_ranked WHERE slug = ?
+)
+SELECT 'prev' AS direction, slug, numero_edicion, edicion_nombre, evento_nombre
+FROM edition_ranked WHERE pos = (SELECT pos FROM current_pos) - 1
+
+UNION ALL
+
+SELECT 'next' AS direction, slug, numero_edicion, edicion_nombre, evento_nombre
+FROM edition_ranked WHERE pos = (SELECT pos FROM current_pos) + 1
+`

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/festivalDetailQuery.test.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/festivalDetailQuery.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test'
+
+import { FESTIVAL_DETAIL_QUERY } from './festivalDetailQuery'
+
+describe('FESTIVAL_DETAIL_QUERY', () => {
+  test('selects edition details with participants and activities', () => {
+    expect(FESTIVAL_DETAIL_QUERY).toContain("'edition_id', ee.id")
+    expect(FESTIVAL_DETAIL_QUERY).toContain("'participantes'")
+    expect(FESTIVAL_DETAIL_QUERY).toContain("'actividades'")
+    expect(FESTIVAL_DETAIL_QUERY).toContain('WHERE ee.slug = ?')
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/festivalDetailQuery.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/adapters/queries/festivalDetailQuery.ts
@@ -1,0 +1,71 @@
+export const FESTIVAL_DETAIL_QUERY = `SELECT json_object(
+  'edition_id', ee.id,
+  'slug', ee.slug,
+  'evento', json_object(
+    'nombre', e.nombre,
+    'slug', e.slug
+  ),
+  'edicion_nombre', ee.nombre,
+  'numero_edicion', ee.numero_edicion,
+  'poster_url', ee.poster_url,
+  'dias', COALESCE((
+    SELECT json_group_array(json_object(
+      'fecha', eed.fecha,
+      'hora_inicio', eed.hora_inicio,
+      'hora_fin', eed.hora_fin,
+      'modalidad', eed.modalidad,
+      'lugar', CASE WHEN l.id IS NOT NULL
+        THEN json_object('nombre', l.nombre, 'direccion', l.direccion)
+        ELSE NULL END
+    ))
+    FROM evento_edicion_dia eed
+    LEFT JOIN lugar l ON eed.lugar_id = l.id
+    WHERE eed.evento_edicion_id = ee.id
+    ORDER BY eed.fecha
+  ), '[]'),
+  'participantes', COALESCE((
+    SELECT json_group_array(json_object(
+      'pseudonimo', COALESCE(a.pseudonimo, ag.nombre, b.name),
+      'disciplina_slug', d.slug,
+      'catalogo_slug', CASE WHEN ca.id IS NOT NULL THEN a.slug ELSE NULL END
+    ))
+    FROM participacion_edicion ped
+    JOIN participacion_exposicion pexp ON pexp.participacion_id = ped.id
+    JOIN disciplina d ON pexp.disciplina_id = d.id
+    LEFT JOIN artista a ON ped.artista_id = a.id
+    LEFT JOIN agrupacion ag ON ped.agrupacion_id = ag.id
+    LEFT JOIN band b ON ped.banda_id = b.id
+    LEFT JOIN catalogo_artista ca ON ca.artista_id = a.id
+      AND ca.activo = 1 AND ca.deleted_at IS NULL
+    WHERE ped.edicion_id = ee.id
+    ORDER BY d.slug, COALESCE(a.pseudonimo, ag.nombre, b.name)
+  ), '[]'),
+  'actividades', COALESCE((
+    SELECT json_group_array(json_object(
+      'titulo', ac.titulo,
+      'descripcion', ac.descripcion,
+      'duracion_minutos', ac.duracion_minutos,
+      'ubicacion', ac.ubicacion,
+      'hora_inicio', ac.hora_inicio,
+      'tipo', ta.slug,
+      'fecha', (
+        SELECT MIN(eed.fecha)
+        FROM evento_edicion_dia eed
+        WHERE eed.evento_edicion_id = ee.id
+      ),
+      'participante_pseudonimo', COALESCE(a2.pseudonimo, ag2.nombre, b2.name)
+    ))
+    FROM participacion_edicion ped2
+    JOIN participacion_actividad pact ON pact.participacion_id = ped2.id
+    LEFT JOIN actividad ac ON ac.participacion_actividad_id = pact.id
+    JOIN tipo_actividad ta ON pact.tipo_actividad_id = ta.id
+    LEFT JOIN artista a2 ON ped2.artista_id = a2.id
+    LEFT JOIN agrupacion ag2 ON ped2.agrupacion_id = ag2.id
+    LEFT JOIN band b2 ON ped2.banda_id = b2.id
+    WHERE ped2.edicion_id = ee.id
+    ORDER BY ac.hora_inicio
+  ), '[]')
+) as resultado
+FROM evento e
+JOIN evento_edicion ee ON e.id = ee.evento_id
+WHERE ee.slug = ?`

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.test.tsx
@@ -1,0 +1,63 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+
+import { ActivityItem } from './ActivityItem'
+
+afterEach(cleanup)
+
+import type { FestivalActivity } from '../../types/festival'
+
+describe('ActivityItem', () => {
+  test('renders title and participant, expands to show details', () => {
+    const activity: FestivalActivity = {
+      titulo: 'Taller de Acuarela',
+      descripcion: 'Introducción a acuarela',
+      duracion_minutos: 90,
+      ubicacion: 'Sala A',
+      hora_inicio: '18:00',
+      tipo: 'taller',
+      fecha: '2025-01-15',
+      participante_pseudonimo: 'Artista Ejemplo'
+    }
+
+    render(<ActivityItem activity={activity} />)
+
+    // Always visible
+    expect(screen.getByText('Taller de Acuarela')).toBeDefined()
+    expect(screen.getByText('Artista Ejemplo')).toBeDefined()
+
+    // Chevron exists (has details)
+    const details = document.querySelector('details')!
+    expect(details).toBeDefined()
+    expect(details.open).toBe(false)
+
+    // Expand via summary click
+    const summary = details.querySelector('summary')!
+    fireEvent.click(summary)
+    expect(details.open).toBe(true)
+
+    expect(screen.getByText('2025-01-15 — 18:00')).toBeDefined()
+    expect(screen.getByText('Sala A')).toBeDefined()
+    expect(screen.getByText('Introducción a acuarela')).toBeDefined()
+    expect(screen.getByText('Duración: 90 min')).toBeDefined()
+  })
+
+  test('renders minimal with participant name, no title or chevron', () => {
+    const activity: FestivalActivity = {
+      titulo: null,
+      descripcion: null,
+      duracion_minutos: null,
+      ubicacion: null,
+      hora_inicio: null,
+      tipo: 'musica',
+      fecha: null,
+      participante_pseudonimo: 'Banda X'
+    }
+
+    render(<ActivityItem activity={activity} />)
+
+    expect(screen.getByText('Banda X')).toBeDefined()
+    expect(screen.queryByRole('heading')).toBeNull()
+    expect(document.querySelector('details')).toBeNull()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.tsx
@@ -23,7 +23,7 @@ export const ActivityItem = ({ activity }: ActivityItemProps) => {
     .join(' — ')
 
   return (
-    <article className='bg-background border-primary group relative max-w-xs rounded-lg border'>
+    <article className='bg-background border-primary group relative max-w-xs min-w-[16rem] rounded-lg border'>
       <div className='bg-primary absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg duration-300 group-hover:translate-0' />
 
       {details ? (

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityItem.tsx
@@ -1,0 +1,100 @@
+import { ChevronDown, Clock, MapPin } from 'lucide-react'
+
+import type { FestivalActivity } from '../../types/festival'
+
+interface ActivityItemProps {
+  activity: FestivalActivity
+}
+
+const hasDetails = (a: FestivalActivity) =>
+  Boolean(
+    a.hora_inicio ||
+    a.fecha ||
+    a.ubicacion ||
+    a.descripcion ||
+    a.duracion_minutos
+  )
+
+export const ActivityItem = ({ activity }: ActivityItemProps) => {
+  const details = hasDetails(activity)
+
+  const timeDisplay = [activity.fecha, activity.hora_inicio]
+    .filter(Boolean)
+    .join(' — ')
+
+  return (
+    <article className='bg-background border-primary group relative max-w-xs rounded-lg border'>
+      <div className='bg-primary absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg duration-300 group-hover:translate-0' />
+
+      {details ? (
+        <details className='group/details'>
+          <summary className='flex w-full cursor-pointer items-center justify-between px-4 py-3 text-left marker:content-none'>
+            <div className='min-w-0 flex-1'>
+              <div className='mb-1 flex flex-wrap items-center gap-2'>
+                {activity.participante_pseudonimo && (
+                  <span className='text-primary/70 text-sm'>
+                    {activity.participante_pseudonimo}
+                  </span>
+                )}
+              </div>
+
+              {activity.titulo && (
+                <h3 className='text-foreground text-base leading-none font-semibold'>
+                  {activity.titulo}
+                </h3>
+              )}
+            </div>
+
+            <ChevronDown
+              className='text-foreground/40 size-5 shrink-0 transition-transform duration-200 group-open/details:rotate-180'
+              aria-hidden='true'
+            />
+          </summary>
+
+          <div className='border-primary/20 h-full overflow-hidden border-t px-4 pt-3 pb-4'>
+            <div className='text-foreground/60 flex flex-wrap gap-4 text-sm'>
+              {timeDisplay && (
+                <div className='flex items-center gap-1.5'>
+                  <Clock className='size-4' aria-hidden='true' />
+                  <time>{timeDisplay}</time>
+                </div>
+              )}
+              {activity.ubicacion && (
+                <div className='flex items-center gap-1.5'>
+                  <MapPin className='size-4' aria-hidden='true' />
+                  <span>{activity.ubicacion}</span>
+                </div>
+              )}
+            </div>
+            {activity.descripcion && (
+              <p className='text-foreground/70 mt-3 text-sm leading-relaxed'>
+                {activity.descripcion}
+              </p>
+            )}
+            {activity.duracion_minutos && (
+              <p className='text-foreground/50 mt-1 text-xs'>
+                Duración: {activity.duracion_minutos} min
+              </p>
+            )}
+          </div>
+        </details>
+      ) : (
+        <div className='px-4 py-3'>
+          <div className='mb-1 flex flex-wrap items-center gap-2'>
+            {activity.participante_pseudonimo && (
+              <span className='text-primary/70 text-sm'>
+                {activity.participante_pseudonimo}
+              </span>
+            )}
+          </div>
+
+          {activity.titulo && (
+            <h3 className='text-foreground text-base leading-none font-semibold'>
+              {activity.titulo}
+            </h3>
+          )}
+        </div>
+      )}
+    </article>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.test.tsx
@@ -1,0 +1,72 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ActivityList } from './ActivityList'
+
+afterEach(cleanup)
+
+import type { FestivalActivity } from '../../types/festival'
+
+describe('ActivityList', () => {
+  test('groups activities by type with Música always last', () => {
+    const actividades: FestivalActivity[] = [
+      {
+        titulo: 'Taller 1',
+        descripcion: null,
+        duracion_minutos: null,
+        ubicacion: null,
+        hora_inicio: '18:00',
+        tipo: 'taller',
+        fecha: '2025-01-15',
+        participante_pseudonimo: 'A'
+      },
+      {
+        titulo: 'Concierto',
+        descripcion: null,
+        duracion_minutos: null,
+        ubicacion: null,
+        hora_inicio: '20:00',
+        tipo: 'musica',
+        fecha: '2025-01-16',
+        participante_pseudonimo: 'B'
+      },
+      {
+        titulo: 'Taller 2',
+        descripcion: null,
+        duracion_minutos: null,
+        ubicacion: null,
+        hora_inicio: '19:00',
+        tipo: 'taller',
+        fecha: '2025-01-15',
+        participante_pseudonimo: 'C'
+      }
+    ]
+
+    render(<ActivityList actividades={actividades} />)
+
+    // All group headings are present
+    expect(screen.getByText('Música')).toBeDefined()
+    expect(screen.getByText('Talleres')).toBeDefined()
+
+    // Música is always the last group heading
+    const headings = screen.getAllByRole('heading', { level: 3 })
+    expect(headings[headings.length - 1].textContent).toBe('Música')
+
+    // Each group renders a list
+    const lists = screen.getAllByRole('list')
+    expect(lists).toHaveLength(2)
+
+    // The last list (Música) has 1 item
+    const lastList = lists[lists.length - 1]
+    expect(lastList.querySelectorAll('li')).toHaveLength(1)
+  })
+
+  test('renders empty when no activities', () => {
+    render(<ActivityList actividades={[]} />)
+
+    // The section header still renders
+    expect(screen.getByText('Actividades')).toBeDefined()
+    // No list items when there are no activities
+    expect(screen.queryAllByRole('listitem')).toHaveLength(0)
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.tsx
@@ -1,0 +1,74 @@
+import { ActivityItem } from './ActivityItem'
+import { MusicActivityItem } from './MusicActivityItem'
+
+import type { FestivalActivity } from '../../types/festival'
+import { cn } from '@/utils/cn'
+
+interface ActivityListProps {
+  actividades: FestivalActivity[]
+}
+
+const TYPE_LABELS: Record<string, string> = {
+  musica: 'Música',
+  taller: 'Talleres',
+  charla: 'Charlas'
+}
+
+const TYPE_ORDER: Record<string, number> = {
+  taller: 0,
+  charla: 1,
+  musica: 99
+}
+
+export const ActivityList = ({ actividades }: ActivityListProps) => {
+  const sorted = [...actividades].sort((a, b) => {
+    const dateA = a.fecha ?? ''
+    const dateB = b.fecha ?? ''
+    if (dateA !== dateB) {
+      return dateA.localeCompare(dateB)
+    }
+    return (a.hora_inicio ?? '').localeCompare(b.hora_inicio ?? '')
+  })
+
+  const grouped = sorted.reduce<Record<string, FestivalActivity[]>>(
+    (acc, activity) => {
+      const key = activity.tipo
+      if (!acc[key]) {
+        acc[key] = []
+      }
+      acc[key].push(activity)
+      return acc
+    },
+    {}
+  )
+
+  return (
+    <section>
+      <h2 className='text-primary mb-6 w-full text-center text-4xl font-bold md:text-start'>
+        Actividades
+      </h2>
+      <div className='flex flex-wrap gap-12 space-y-8'>
+        {Object.entries(grouped)
+          .sort(([a], [b]) => (TYPE_ORDER[a] ?? 99) - (TYPE_ORDER[b] ?? 99))
+          .map(([tipo, group]) => (
+            <section key={tipo}>
+              <h3 className='text-accent mb-3 font-mono text-2xl font-bold'>
+                {TYPE_LABELS[tipo] ?? tipo}
+              </h3>
+              <ul className={cn(tipo === 'musica' ? 'space-y-2' : 'space-y-3')}>
+                {group.map((activity, index) => (
+                  <li key={`${tipo}-${activity.titulo ?? index}-${index}`}>
+                    {tipo !== 'musica' ? (
+                      <ActivityItem activity={activity} />
+                    ) : (
+                      <MusicActivityItem activity={activity} />
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </section>
+          ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ActivityList.tsx
@@ -51,8 +51,8 @@ export const ActivityList = ({ actividades }: ActivityListProps) => {
         {Object.entries(grouped)
           .sort(([a], [b]) => (TYPE_ORDER[a] ?? 99) - (TYPE_ORDER[b] ?? 99))
           .map(([tipo, group]) => (
-            <section key={tipo}>
-              <h3 className='text-accent mb-3 font-mono text-2xl font-bold'>
+            <section key={tipo} className='flex-1'>
+              <h3 className='text-accent mb-3 text-center font-mono text-2xl font-bold md:text-start'>
                 {TYPE_LABELS[tipo] ?? tipo}
               </h3>
               <ul className={cn(tipo === 'musica' ? 'space-y-2' : 'space-y-3')}>

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.test.tsx
@@ -1,0 +1,80 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { FestivalDetailContent } from './FestivalDetailContent'
+
+afterEach(cleanup)
+
+import type { FestivalDetail } from '../../types/festival'
+
+const baseDetail: FestivalDetail = {
+  edition_id: 10,
+  slug: 'edicion-15-1',
+  evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+  edicion_nombre: 'Un Nuevo Germinar',
+  numero_edicion: 'XV',
+  poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+  dias: [
+    {
+      fecha: '2025-10-03',
+      hora_inicio: '11:00',
+      hora_fin: '20:00',
+      modalidad: 'presencial',
+      lugar: { nombre: 'Casa ULS', direccion: 'Av. Solari 1301' }
+    }
+  ],
+  participantes: [
+    {
+      pseudonimo: 'Artista Ejemplo',
+      disciplina_slug: 'Ilustración',
+      catalogo_slug: 'artista-ejemplo'
+    }
+  ],
+  actividades: [
+    {
+      titulo: 'Taller de Acuarela',
+      descripcion: null,
+      duracion_minutos: 60,
+      ubicacion: 'Sala A',
+      hora_inicio: '18:00',
+      tipo: 'taller',
+      fecha: '2025-10-03',
+      participante_pseudonimo: 'Artista Ejemplo'
+    }
+  ]
+}
+
+describe('FestivalDetailContent', () => {
+  test('renders event name, edition and dates', () => {
+    render(<FestivalDetailContent detail={baseDetail} />)
+
+    expect(
+      screen.getByRole('heading', { name: /Festival Frijol Mágico/i })
+    ).toBeDefined()
+    expect(screen.getByText('Un Nuevo Germinar')).toBeDefined()
+    expect(screen.getByText('3 de octubre de 2025')).toBeDefined()
+  })
+
+  test('renders participants and activities sections', () => {
+    render(<FestivalDetailContent detail={baseDetail} />)
+
+    expect(screen.getByText('Participantes')).toBeDefined()
+    expect(screen.getByText('Actividades')).toBeDefined()
+    expect(screen.getByRole('link', { name: 'Artista Ejemplo' })).toBeDefined()
+    expect(screen.getByText('Taller de Acuarela')).toBeDefined()
+  })
+
+  test('renders fallback edition name when edicion_nombre is null', () => {
+    const detail: FestivalDetail = {
+      ...baseDetail,
+      edicion_nombre: null
+    }
+
+    render(<FestivalDetailContent detail={detail} />)
+
+    // The edition number is rendered as part of the main heading
+    const heading = screen.getByRole('heading', { level: 1 })
+    expect(heading.textContent).toContain('XV')
+    expect(heading.textContent).toContain('Festival Frijol Mágico')
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.test.tsx
@@ -1,11 +1,22 @@
-import { afterEach, describe, expect, test } from 'bun:test'
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ReactNode } from 'react'
 import { cleanup, render, screen } from '@testing-library/react'
 
 import { FestivalDetailContent } from './FestivalDetailContent'
 
-afterEach(cleanup)
-
 import type { FestivalDetail } from '../../types/festival'
+
+mock.module('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  )
+}))
+
+mock.module('./FestivalNavigator', () => ({
+  FestivalNavigator: async () => null
+}))
+
+afterEach(cleanup)
 
 const baseDetail: FestivalDetail = {
   edition_id: 10,
@@ -44,9 +55,16 @@ const baseDetail: FestivalDetail = {
   ]
 }
 
+// Helper: call async component as a function and render the returned JSX
+async function renderAsync(
+  element: Promise<JSX.Element> | JSX.Element
+): Promise<ReturnType<typeof render>> {
+  return render(await element)
+}
+
 describe('FestivalDetailContent', () => {
-  test('renders event name, edition and dates', () => {
-    render(<FestivalDetailContent detail={baseDetail} />)
+  test('renders event name, edition and dates', async () => {
+    await renderAsync(FestivalDetailContent({ detail: baseDetail }))
 
     expect(
       screen.getByRole('heading', { name: /Festival Frijol Mágico/i })
@@ -55,8 +73,8 @@ describe('FestivalDetailContent', () => {
     expect(screen.getByText('3 de octubre de 2025')).toBeDefined()
   })
 
-  test('renders participants and activities sections', () => {
-    render(<FestivalDetailContent detail={baseDetail} />)
+  test('renders participants and activities sections', async () => {
+    await renderAsync(FestivalDetailContent({ detail: baseDetail }))
 
     expect(screen.getByText('Participantes')).toBeDefined()
     expect(screen.getByText('Actividades')).toBeDefined()
@@ -64,15 +82,14 @@ describe('FestivalDetailContent', () => {
     expect(screen.getByText('Taller de Acuarela')).toBeDefined()
   })
 
-  test('renders fallback edition name when edicion_nombre is null', () => {
+  test('renders fallback edition name when edicion_nombre is null', async () => {
     const detail: FestivalDetail = {
       ...baseDetail,
       edicion_nombre: null
     }
 
-    render(<FestivalDetailContent detail={detail} />)
+    await renderAsync(FestivalDetailContent({ detail }))
 
-    // The edition number is rendered as part of the main heading
     const heading = screen.getByRole('heading', { level: 1 })
     expect(heading.textContent).toContain('XV')
     expect(heading.textContent).toContain('Festival Frijol Mágico')

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.tsx
@@ -1,0 +1,69 @@
+import { Calendar, MapPin } from 'lucide-react'
+
+import { FestivalDetailPoster } from './FestivalDetailPoster'
+import { ParticipantList } from './ParticipantList'
+import { ActivityList } from './ActivityList'
+
+import { getDaysDisplay, getLocation } from '../../utils/timelineUtils'
+
+import type { FestivalDetail } from '../../types/festival'
+
+interface FestivalDetailContentProps {
+  detail: FestivalDetail
+}
+
+export const FestivalDetailContent = ({
+  detail
+}: FestivalDetailContentProps) => {
+  const { evento, edicion_nombre, numero_edicion, poster_url, dias } = detail
+
+  const daysDisplay = getDaysDisplay(dias)
+  const locationDisplay = getLocation(dias)
+
+  return (
+    <article className='container mx-auto max-w-6xl px-4 pt-16 pb-32'>
+      <header className='mb-8'>
+        <h1 className='text-primary text-4xl leading-none font-black tracking-tight md:text-5xl'>
+          <span className='text-secondary'>{numero_edicion}</span>{' '}
+          {evento.nombre}
+        </h1>
+        {edicion_nombre && (
+          <p className='text-accent text-xl font-semibold'>{edicion_nombre}</p>
+        )}
+
+        <div className='mt-4 space-y-2'>
+          {daysDisplay && (
+            <div className='text-foreground/70 flex items-center gap-2'>
+              <Calendar className='size-5' aria-hidden='true' />
+              <span>{daysDisplay}</span>
+            </div>
+          )}
+          {locationDisplay && (
+            <div className='text-foreground/70 flex items-center gap-2'>
+              <MapPin className='size-5' aria-hidden='true' />
+              <span>{locationDisplay}</span>
+            </div>
+          )}
+        </div>
+      </header>
+
+      <div className='grid gap-10 md:grid-cols-8 lg:gap-20'>
+        <aside className='md:sticky md:top-24 md:col-span-3 md:self-start'>
+          <FestivalDetailPoster
+            posterUrl={poster_url}
+            eventName={evento.nombre}
+            editionName={numero_edicion}
+            priority
+          />
+        </aside>
+
+        <div className='min-w-0 space-y-8 md:col-span-5'>
+          <ParticipantList participantes={detail.participantes} />
+          {detail.actividades.length > 0 && (
+            <ActivityList actividades={detail.actividades} />
+          )}
+        </div>
+      </div>
+    </article>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailContent.tsx
@@ -7,12 +7,13 @@ import { ActivityList } from './ActivityList'
 import { getDaysDisplay, getLocation } from '../../utils/timelineUtils'
 
 import type { FestivalDetail } from '../../types/festival'
+import { FestivalNavigator } from './FestivalNavigator'
 
 interface FestivalDetailContentProps {
   detail: FestivalDetail
 }
 
-export const FestivalDetailContent = ({
+export const FestivalDetailContent = async ({
   detail
 }: FestivalDetailContentProps) => {
   const { evento, edicion_nombre, numero_edicion, poster_url, dias } = detail

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.test.tsx
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, test } from 'bun:test'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { FestivalDetailPoster } from './FestivalDetailPoster'
+
+afterEach(cleanup)
+
+describe('FestivalDetailPoster', () => {
+  test('renders image when poster URL is provided', () => {
+    render(
+      <FestivalDetailPoster
+        posterUrl='https://cdn.frijolmagico.cl/poster.webp'
+        eventName='Festival Frijol Mágico'
+        editionName='Edición XV'
+        priority
+      />
+    )
+
+    const image = screen.getByAltText('Afiche Festival Frijol Mágico Edición XV')
+    expect(image).toBeDefined()
+  })
+
+  test('renders gradient fallback with event name when no poster URL', () => {
+    render(
+      <FestivalDetailPoster
+        posterUrl={null}
+        eventName='Festival Frijol Mágico'
+        editionName='XV'
+        priority={false}
+      />
+    )
+
+    expect(
+      screen.getByText('Festival Frijol Mágico')
+    ).toBeDefined()
+    expect(screen.queryByRole('img')).toBeNull()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.tsx
@@ -1,0 +1,49 @@
+import Image from 'next/image'
+
+import { cn } from '@/utils/cn'
+import { FestivalTimelineCardBacklight } from '../../components/FestivalTimelineCardBacklight'
+
+interface FestivalDetailPosterProps {
+  posterUrl: string | null
+  eventName: string
+  editionName: string
+  priority: boolean
+}
+
+export const FestivalDetailPoster = ({
+  posterUrl,
+  eventName,
+  editionName,
+  priority
+}: FestivalDetailPosterProps) => (
+  <figure className='relatie relative aspect-auto h-auto w-full'>
+    {posterUrl ? (
+      <Image
+        src={posterUrl}
+        alt={`Afiche ${eventName} ${editionName}`}
+        width={370}
+        height={523}
+        className='aspect-auto w-full rounded-xl object-cover'
+        priority={priority}
+        sizes='(max-width: 768px) 320px, 370'
+      />
+    ) : (
+      <div
+        className={cn(
+          'from-secondary to-accent flex size-full flex-col items-center justify-center',
+          'border-primary rounded-xl border-2 bg-linear-to-br p-4 text-center shadow-xl'
+        )}
+      >
+        <span className='text-background text-3xl leading-none font-black drop-shadow-lg md:text-5xl'>
+          {eventName}
+        </span>
+        {editionName && (
+          <span className='text-background mt-2 text-xl font-semibold md:text-2xl'>
+            {editionName}
+          </span>
+        )}
+      </div>
+    )}
+    <FestivalTimelineCardBacklight isActive />
+  </figure>
+)

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalDetailPoster.tsx
@@ -16,14 +16,14 @@ export const FestivalDetailPoster = ({
   editionName,
   priority
 }: FestivalDetailPosterProps) => (
-  <figure className='relatie relative aspect-auto h-auto w-full'>
+  <figure className='relative aspect-auto h-auto w-full'>
     {posterUrl ? (
       <Image
         src={posterUrl}
         alt={`Afiche ${eventName} ${editionName}`}
         width={370}
         height={523}
-        className='aspect-auto w-full rounded-xl object-cover'
+        className='aspect-auto h-auto w-full rounded-xl object-cover'
         priority={priority}
         sizes='(max-width: 768px) 320px, 370'
       />

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalNavigator.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalNavigator.tsx
@@ -1,7 +1,10 @@
 import Link from 'next/link'
 import { ArrowLeft, ArrowRight } from 'lucide-react'
 
-import type { AdjacentFestival } from '../lib/getAdjacentFestivals'
+import {
+  getAdjacentFestivals,
+  type AdjacentFestival
+} from '../lib/getAdjacentFestivals'
 
 // ——— Sub-component ———
 
@@ -11,32 +14,32 @@ interface NavigatorCardProps {
 }
 
 const NavigatorCard = ({ festival, direction }: NavigatorCardProps) => {
-  const Arrow = direction === 'prev' ? ArrowLeft : ArrowRight
   const href = `/festivales/${festival.slug}`
   const isPrev = direction === 'prev'
 
   return (
     <Link
       href={href}
-      className='group relative rounded-lg border-2 border-primary bg-background'
+      className='group border-foreground bg-primary relative rounded-lg border'
     >
       {/* Backlight — same pattern as ActivityItem */}
-      <div className='absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg bg-primary transition-transform duration-300 group-hover:translate-x-0 group-hover:translate-y-0' />
+      <div className='bg-foreground absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg transition-transform duration-300 group-hover:translate-x-0 group-hover:translate-y-0' />
 
       <div className='flex items-center gap-3 p-4'>
         {isPrev && (
           <ArrowLeft
-            className='size-5 shrink-0 text-primary'
+            className='text-background size-5 shrink-0'
             aria-hidden='true'
           />
         )}
 
         <div className='min-w-0 flex-1'>
-          <p className='text-lg leading-tight font-bold text-primary'>
-            {festival.numero_edicion} {festival.evento_nombre}
+          <p className='text-background text-lg leading-none font-bold'>
+            {festival.evento_nombre}{' '}
+            <span className='text-secondary'>{festival.numero_edicion}</span>
           </p>
           {festival.edicion_nombre && (
-            <p className='text-sm font-semibold text-accent'>
+            <p className='text-accent text-sm font-semibold'>
               {festival.edicion_nombre}
             </p>
           )}
@@ -44,7 +47,7 @@ const NavigatorCard = ({ festival, direction }: NavigatorCardProps) => {
 
         {!isPrev && (
           <ArrowRight
-            className='size-5 shrink-0 text-primary'
+            className='text-background size-5 shrink-0'
             aria-hidden='true'
           />
         )}
@@ -56,23 +59,22 @@ const NavigatorCard = ({ festival, direction }: NavigatorCardProps) => {
 // ——— Main component ———
 
 interface FestivalNavigatorProps {
-  prev: AdjacentFestival | null
-  next: AdjacentFestival | null
+  slug: string
 }
 
-export const FestivalNavigator = ({
-  prev,
-  next
-}: FestivalNavigatorProps) => {
+export const FestivalNavigator = async ({ slug }: FestivalNavigatorProps) => {
+  if (!slug) return null
+
+  const { prev, next } = await getAdjacentFestivals(slug)
   if (!prev && !next) return null
 
   return (
     <nav
-      className='container mx-auto max-w-6xl px-4 pb-32'
+      className='container mx-auto max-w-6xl'
       aria-label='Navegación entre ediciones'
     >
-      <h2 className='mb-6 text-2xl font-bold text-foreground'>
-        Más festivales
+      <h2 className='text-primary mb-6 w-full text-center text-4xl font-bold md:text-start'>
+        Otras ediciones
       </h2>
 
       <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalNavigator.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/FestivalNavigator.tsx
@@ -1,0 +1,92 @@
+import Link from 'next/link'
+import { ArrowLeft, ArrowRight } from 'lucide-react'
+
+import type { AdjacentFestival } from '../lib/getAdjacentFestivals'
+
+// ——— Sub-component ———
+
+interface NavigatorCardProps {
+  festival: AdjacentFestival
+  direction: 'prev' | 'next'
+}
+
+const NavigatorCard = ({ festival, direction }: NavigatorCardProps) => {
+  const Arrow = direction === 'prev' ? ArrowLeft : ArrowRight
+  const href = `/festivales/${festival.slug}`
+  const isPrev = direction === 'prev'
+
+  return (
+    <Link
+      href={href}
+      className='group relative rounded-lg border-2 border-primary bg-background'
+    >
+      {/* Backlight — same pattern as ActivityItem */}
+      <div className='absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg bg-primary transition-transform duration-300 group-hover:translate-x-0 group-hover:translate-y-0' />
+
+      <div className='flex items-center gap-3 p-4'>
+        {isPrev && (
+          <ArrowLeft
+            className='size-5 shrink-0 text-primary'
+            aria-hidden='true'
+          />
+        )}
+
+        <div className='min-w-0 flex-1'>
+          <p className='text-lg leading-tight font-bold text-primary'>
+            {festival.numero_edicion} {festival.evento_nombre}
+          </p>
+          {festival.edicion_nombre && (
+            <p className='text-sm font-semibold text-accent'>
+              {festival.edicion_nombre}
+            </p>
+          )}
+        </div>
+
+        {!isPrev && (
+          <ArrowRight
+            className='size-5 shrink-0 text-primary'
+            aria-hidden='true'
+          />
+        )}
+      </div>
+    </Link>
+  )
+}
+
+// ——— Main component ———
+
+interface FestivalNavigatorProps {
+  prev: AdjacentFestival | null
+  next: AdjacentFestival | null
+}
+
+export const FestivalNavigator = ({
+  prev,
+  next
+}: FestivalNavigatorProps) => {
+  if (!prev && !next) return null
+
+  return (
+    <nav
+      className='container mx-auto max-w-6xl px-4 pb-32'
+      aria-label='Navegación entre ediciones'
+    >
+      <h2 className='mb-6 text-2xl font-bold text-foreground'>
+        Más festivales
+      </h2>
+
+      <div className='grid grid-cols-1 gap-4 md:grid-cols-2'>
+        {prev ? (
+          <NavigatorCard festival={prev} direction='prev' />
+        ) : (
+          <div aria-hidden='true' />
+        )}
+        {next ? (
+          <NavigatorCard festival={next} direction='next' />
+        ) : (
+          <div aria-hidden='true' />
+        )}
+      </div>
+    </nav>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/MusicActivityItem.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/MusicActivityItem.tsx
@@ -7,7 +7,7 @@ interface MusicActivityItemProps {
 export const MusicActivityItem = ({ activity }: MusicActivityItemProps) => (
   <article className='bg-background relative max-w-sm'>
     {activity.participante_pseudonimo && (
-      <span className='text-primary block text-lg font-semibold'>
+      <span className='text-primary block text-center text-lg font-semibold md:text-start'>
         {activity.participante_pseudonimo}
       </span>
     )}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/MusicActivityItem.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/MusicActivityItem.tsx
@@ -1,0 +1,15 @@
+import type { FestivalActivity } from '../../types/festival'
+
+interface MusicActivityItemProps {
+  activity: FestivalActivity
+}
+
+export const MusicActivityItem = ({ activity }: MusicActivityItemProps) => (
+  <article className='bg-background relative max-w-sm'>
+    {activity.participante_pseudonimo && (
+      <span className='text-primary block text-lg font-semibold'>
+        {activity.participante_pseudonimo}
+      </span>
+    )}
+  </article>
+)

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantByDiscipline.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantByDiscipline.test.tsx
@@ -1,0 +1,31 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ParticipantByDiscipline } from './ParticipantByDiscipline'
+
+afterEach(cleanup)
+
+mock.module('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  )
+}))
+
+describe('ParticipantByDiscipline', () => {
+  test('renders discipline heading and participant items', () => {
+    render(
+      <ParticipantByDiscipline
+        disciplineLabel='Ilustración'
+        participants={[
+          { pseudonimo: 'Artista A', disciplina_slug: 'Ilustración', catalogo_slug: 'a' },
+          { pseudonimo: 'Artista B', disciplina_slug: 'Ilustración', catalogo_slug: null }
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Ilustración' })).toBeDefined()
+    expect(screen.getByText('Artista A')).toBeDefined()
+    expect(screen.getByText('Artista B')).toBeDefined()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantByDiscipline.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantByDiscipline.tsx
@@ -1,0 +1,29 @@
+import { ParticipantItem } from './ParticipantItem'
+
+import type { FestivalParticipant } from '../../types/festival'
+
+interface ParticipantByDisciplineProps {
+  disciplineLabel: string
+  participants: FestivalParticipant[]
+}
+
+export const ParticipantByDiscipline = ({
+  disciplineLabel,
+  participants
+}: ParticipantByDisciplineProps) => (
+  <section className='w-full text-center md:w-auto md:text-start'>
+    <h3 className='text-accent mb-3 font-mono text-2xl font-bold'>
+      {disciplineLabel}
+    </h3>
+    <ul className='flex w-full flex-col flex-wrap space-y-1 md:max-h-[80dvh] lg:max-h-[50dvh]'>
+      {participants.map((participant) => (
+        <li key={participant.pseudonimo} className='md:mr-8'>
+          <ParticipantItem
+            pseudonimo={participant.pseudonimo}
+            catalogoSlug={participant.catalogo_slug}
+          />
+        </li>
+      ))}
+    </ul>
+  </section>
+)

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantItem.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantItem.test.tsx
@@ -1,0 +1,35 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ParticipantItem } from './ParticipantItem'
+
+afterEach(cleanup)
+
+mock.module('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  )
+}))
+
+describe('ParticipantItem', () => {
+  test('renders link for catalog participants', () => {
+    render(
+      <ParticipantItem
+        pseudonimo='Artista Ejemplo'
+        catalogoSlug='artista-ejemplo'
+      />
+    )
+
+    const link = screen.getByRole('link', { name: 'Artista Ejemplo' })
+    expect(link).toBeDefined()
+    expect(link.getAttribute('href')).toBe('/catalogo/artista-ejemplo')
+  })
+
+  test('renders plain text for non-catalog participants', () => {
+    render(<ParticipantItem pseudonimo='Colectivo X' catalogoSlug={null} />)
+
+    expect(screen.getByText('Colectivo X')).toBeDefined()
+    expect(screen.queryByRole('link')).toBeNull()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantItem.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantItem.tsx
@@ -1,0 +1,26 @@
+import Link from 'next/link'
+import { ArrowRightIcon } from 'lucide-react'
+
+interface ParticipantItemProps {
+  pseudonimo: string
+  catalogoSlug: string | null
+}
+
+export const ParticipantItem = ({
+  pseudonimo,
+  catalogoSlug
+}: ParticipantItemProps) => {
+  if (catalogoSlug) {
+    return (
+      <Link
+        href={`/catalogo/${catalogoSlug}`}
+        className='hover:text-link text-primary group mx-auto flex w-fit items-center gap-1 duration-200 md:mx-0'
+      >
+        {pseudonimo}
+        <ArrowRightIcon className='size-4 opacity-50 duration-200 group-hover:-rotate-45' />
+      </Link>
+    )
+  }
+
+  return <span className='text-foreground/80'>{pseudonimo}</span>
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantList.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantList.test.tsx
@@ -1,0 +1,51 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { ParticipantList } from './ParticipantList'
+
+afterEach(cleanup)
+
+mock.module('next/link', () => ({
+  default: ({ href, children }: { href: string; children: ReactNode }) => (
+    <a href={href}>{children}</a>
+  )
+}))
+
+describe('ParticipantList', () => {
+  test('groups participants by discipline and renders sections', () => {
+    render(
+      <ParticipantList
+        participantes={[
+          {
+            pseudonimo: 'Artista A',
+            disciplina_slug: 'Ilustración',
+            catalogo_slug: null
+          },
+          {
+            pseudonimo: 'Artista B',
+            disciplina_slug: 'Ilustración',
+            catalogo_slug: null
+          },
+          {
+            pseudonimo: 'Artista C',
+            disciplina_slug: 'Manualidades',
+            catalogo_slug: null
+          }
+        ]}
+      />
+    )
+
+    expect(screen.getByRole('heading', { name: 'Ilustración' })).toBeDefined()
+    expect(screen.getByRole('heading', { name: 'Manualidades' })).toBeDefined()
+    expect(screen.getByText('Artista A')).toBeDefined()
+    expect(screen.getByText('Artista B')).toBeDefined()
+    expect(screen.getByText('Artista C')).toBeDefined()
+  })
+
+  test('renders empty message when no participants', () => {
+    render(<ParticipantList participantes={[]} />)
+
+    expect(screen.getByText('Sin participantes registrados aún')).toBeDefined()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantList.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/components/ParticipantList.tsx
@@ -1,0 +1,49 @@
+import { ParticipantByDiscipline } from './ParticipantByDiscipline'
+
+import type { FestivalParticipant } from '../../types/festival'
+
+interface ParticipantListProps {
+  participantes: FestivalParticipant[]
+}
+
+export const ParticipantList = ({ participantes }: ParticipantListProps) => {
+  if (participantes.length === 0) {
+    return (
+      <section>
+        <h2 className='text-primary mb-6 w-full text-4xl font-bold'>
+          Participantes
+        </h2>
+        <p className='text-foreground/60'>Sin participantes registrados aún</p>
+      </section>
+    )
+  }
+
+  const grouped = participantes.reduce<Record<string, FestivalParticipant[]>>(
+    (acc, participant) => {
+      const key = participant.disciplina_slug
+      if (!acc[key]) {
+        acc[key] = []
+      }
+      acc[key].push(participant)
+      return acc
+    },
+    {}
+  )
+
+  return (
+    <section>
+      <h2 className='text-primary mb-6 w-full text-center text-4xl font-bold md:text-start'>
+        Participantes
+      </h2>
+      <div className='flex flex-wrap gap-6'>
+        {Object.entries(grouped).map(([disciplineLabel, group]) => (
+          <ParticipantByDiscipline
+            key={disciplineLabel}
+            disciplineLabel={disciplineLabel}
+            participants={group}
+          />
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/lib/getAdjacentFestivals.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/lib/getAdjacentFestivals.ts
@@ -1,0 +1,23 @@
+import { cacheTag } from 'next/cache'
+
+import {
+  EDITION_CACHE_TAG,
+  FESTIVALES_CACHE_TAG
+} from '@frijolmagico/cache-tags'
+
+import {
+  adjacentFestivalsRepository,
+  type AdjacentFestivalsResult
+} from '../adapters/adjacentFestivalsRepository'
+
+export type { AdjacentFestival } from '../adapters/adjacentFestivalsRepository'
+
+export async function getAdjacentFestivals(
+  slug: string
+): Promise<AdjacentFestivalsResult> {
+  'use cache'
+  cacheTag(FESTIVALES_CACHE_TAG)
+  cacheTag(EDITION_CACHE_TAG)
+
+  return adjacentFestivalsRepository(slug)
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalBySlug.test.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalBySlug.test.ts
@@ -1,0 +1,60 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { notFound } from 'next/navigation'
+
+import { executeQueryMock } from '@/test-utils/mockDatabase'
+
+import { getFestivalBySlug } from './getFestivalBySlug'
+
+mock.module('next/navigation', () => ({
+  notFound: mock(() => {
+    throw new Error('NOT_FOUND')
+  })
+}))
+
+mock.module('next/cache', () => ({
+  cacheTag: mock(() => {})
+}))
+
+beforeEach(() => {
+  executeQueryMock.mockReset()
+})
+
+const baseRawResult = {
+  resultado: JSON.stringify({
+    edition_id: 10,
+    slug: 'edicion-15-1',
+    evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+    edicion_nombre: 'Un Nuevo Germinar',
+    numero_edicion: 'XV',
+    poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+    dias: [],
+    participantes: [],
+    actividades: []
+  })
+}
+
+describe('getFestivalBySlug', () => {
+  test('returns detail when repository finds a festival', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [baseRawResult],
+      error: null
+    })
+
+    const result = await getFestivalBySlug('edicion-15-1')
+
+    expect(result.slug).toBe('edicion-15-1')
+  })
+
+  test('calls notFound when repository returns null', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [],
+      error: null
+    })
+
+    await expect(getFestivalBySlug('edicion-999-999')).rejects.toThrow(
+      'NOT_FOUND'
+    )
+    expect(notFound).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalBySlug.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalBySlug.ts
@@ -1,0 +1,27 @@
+import { notFound } from 'next/navigation'
+import { cacheTag } from 'next/cache'
+
+import {
+  EDITION_CACHE_TAG,
+  EVENT_CACHE_TAG,
+  FESTIVALES_CACHE_TAG
+} from '@frijolmagico/cache-tags'
+
+import { festivalDetailRepository } from '../adapters/festivalDetailRepository'
+
+import type { FestivalDetail } from '../../types/festival'
+
+export async function getFestivalBySlug(slug: string): Promise<FestivalDetail> {
+  'use cache'
+  cacheTag(FESTIVALES_CACHE_TAG)
+  cacheTag(EVENT_CACHE_TAG)
+  cacheTag(EDITION_CACHE_TAG)
+
+  const detail = await festivalDetailRepository(slug)
+
+  if (!detail) {
+    notFound()
+  }
+
+  return detail
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalSlugs.test.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalSlugs.test.ts
@@ -1,0 +1,46 @@
+import { beforeEach, describe, expect, test } from 'bun:test'
+
+import { executeQueryMock } from '@/test-utils/mockDatabase'
+
+import { getFestivalSlugs } from './getFestivalSlugs'
+
+beforeEach(() => {
+  executeQueryMock.mockReset()
+})
+
+describe('getFestivalSlugs', () => {
+  test('returns slugs from query results', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [{ slug: 'edicion-15-1' }, { slug: 'edicion-14-1' }],
+      error: null
+    })
+
+    const slugs = await getFestivalSlugs()
+
+    expect(slugs).toEqual(['edicion-15-1', 'edicion-14-1'])
+  })
+
+  test('filters out null or empty slugs', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [{ slug: 'edicion-15-1' }, { slug: null }, { slug: '' }],
+      error: null
+    })
+
+    const slugs = await getFestivalSlugs()
+
+    expect(slugs).toEqual(['edicion-15-1'])
+  })
+
+  test('falls back to mock slugs when query fails', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [],
+      error: new Error('DB error')
+    })
+
+    const slugs = await getFestivalSlugs()
+
+    // Should fall back to mock data slugs
+    expect(slugs.length).toBeGreaterThan(0)
+    expect(slugs).toContain('edicion-xv-1')
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalSlugs.ts
+++ b/apps/web/src/app/(sections)/festivales/[slug]/lib/getFestivalSlugs.ts
@@ -1,0 +1,37 @@
+import { executeQuery } from '@frijolmagico/database/client'
+import { getDataSource } from '@/infra/config/dataSourceConfig'
+import { getFestivalesMock } from '../../adapters/mocks/festivalesData.mock'
+
+const FESTIVAL_SLUGS_QUERY = `SELECT ee.slug
+FROM evento_edicion ee
+JOIN evento e ON e.id = ee.evento_id
+ORDER BY ee.id DESC`
+
+function getMockSlugs(): string[] {
+  return getFestivalesMock()
+    .map((f) => f.evento.edicion_slug)
+    .filter(Boolean)
+}
+
+export async function getFestivalSlugs(): Promise<string[]> {
+  const source = getDataSource({ prod: 'database' })
+
+  if (source === 'local' || source === 'database') {
+    const { data, error } = await executeQuery<{ slug: string | null }>(
+      FESTIVAL_SLUGS_QUERY,
+      []
+    )
+
+    if (!error && data && data.length > 0) {
+      return data
+        .map((row) => row.slug)
+        .filter((slug): slug is string => Boolean(slug && slug.trim()))
+    }
+
+    console.warn(
+      '⚠️ Database query failed for festival slugs, falling back to mock data'
+    )
+  }
+
+  return getMockSlugs()
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/page.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/page.test.tsx
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+import { notFound } from 'next/navigation'
+
+import { executeQueryMock } from '@/test-utils/mockDatabase'
+
+import FestivalDetailPage, {
+  generateMetadata,
+  generateStaticParams
+} from './page'
+
+mock.module('next/navigation', () => ({
+  notFound: mock(() => {
+    throw new Error('NOT_FOUND')
+  })
+}))
+
+mock.module('next/cache', () => ({
+  cacheTag: mock(() => {})
+}))
+
+beforeEach(() => {
+  executeQueryMock.mockReset()
+})
+
+const buildSlugRow = (slug: string) => ({ slug })
+
+const buildDetailRow = (detail: Record<string, unknown>) => ({
+  resultado: JSON.stringify(detail)
+})
+
+const baseDetail = {
+  edition_id: 10,
+  slug: 'edicion-15-1',
+  evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+  edicion_nombre: 'Un Nuevo Germinar',
+  numero_edicion: 'XV',
+  poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+  dias: [],
+  participantes: [],
+  actividades: []
+}
+
+describe('FestivalDetailPage', () => {
+  test('generateStaticParams returns slugs wrapped in params', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [
+        buildSlugRow('edicion-15-1'),
+        buildSlugRow('edicion-14-1')
+      ],
+      error: null
+    })
+
+    const params = await generateStaticParams()
+
+    expect(params).toEqual([
+      { slug: 'edicion-15-1' },
+      { slug: 'edicion-14-1' }
+    ])
+  })
+
+  test('generateMetadata builds title and OG image from detail', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [buildDetailRow(baseDetail)],
+      error: null
+    })
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'edicion-15-1' })
+    })
+
+    expect(metadata.title).toBe(
+      'Un Nuevo Germinar - Festival Frijol Mágico | Frijol Mágico'
+    )
+    expect(metadata.openGraph?.images).toEqual([
+      { url: 'https://cdn.frijolmagico.cl/poster.webp' }
+    ])
+  })
+
+  test('generateMetadata handles missing poster', async () => {
+    executeQueryMock.mockResolvedValueOnce({
+      data: [buildDetailRow({ ...baseDetail, poster_url: null })],
+      error: null
+    })
+
+    const metadata = await generateMetadata({
+      params: Promise.resolve({ slug: 'edicion-15-1' })
+    })
+
+    expect(metadata.title).toContain('Festival Frijol Mágico')
+    expect(metadata.openGraph?.images).toEqual([])
+  })
+
+  test('page calls notFound when slug is missing', async () => {
+    await expect(
+      FestivalDetailPage({ params: Promise.resolve({ slug: '' }) })
+    ).rejects.toThrow('NOT_FOUND')
+    expect(notFound).toHaveBeenCalled()
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
@@ -1,0 +1,69 @@
+import { notFound } from 'next/navigation'
+import type { Metadata } from 'next'
+
+import { TrackPageView } from '@/components/analytics/TrackPageView'
+
+import { getFestivalBySlug } from './lib/getFestivalBySlug'
+import { getFestivalSlugs } from './lib/getFestivalSlugs'
+
+import { FestivalDetailContent } from './components/FestivalDetailContent'
+
+export async function generateStaticParams() {
+  const slugs = await getFestivalSlugs()
+  return slugs.map((slug) => ({ slug }))
+}
+
+export async function generateMetadata({
+  params
+}: {
+  params: Promise<{ slug: string }>
+}): Promise<Metadata> {
+  const { slug } = await params
+
+  if (!slug) {
+    return { title: 'Festival no encontrado | Frijol Mágico' }
+  }
+
+  const detail = await getFestivalBySlug(slug)
+
+  if (!detail) {
+    return { title: 'Festival no encontrado | Frijol Mágico' }
+  }
+
+  const title = `${detail.edicion_nombre ?? `Edición ${detail.numero_edicion}`} - ${detail.evento.nombre} | Frijol Mágico`
+  const description = `Participantes y actividades de ${detail.evento.nombre}.`
+
+  return {
+    title,
+    description,
+    openGraph: {
+      title,
+      description,
+      images: detail.poster_url ? [{ url: detail.poster_url }] : []
+    }
+  }
+}
+
+export default async function FestivalDetailPage({
+  params
+}: {
+  params: Promise<{ slug: string }>
+}) {
+  const { slug } = await params
+
+  if (!slug) notFound()
+
+  const detail = await getFestivalBySlug(slug)
+
+  if (!detail) notFound()
+
+  return (
+    <>
+      <TrackPageView
+        sectionName={`Festivales - ${detail.evento.nombre}`}
+        sectionPath={`/festivales/${slug}`}
+      />
+      <FestivalDetailContent detail={detail} />
+    </>
+  )
+}

--- a/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
@@ -5,8 +5,10 @@ import { TrackPageView } from '@/components/analytics/TrackPageView'
 
 import { getFestivalBySlug } from './lib/getFestivalBySlug'
 import { getFestivalSlugs } from './lib/getFestivalSlugs'
+import { getAdjacentFestivals } from './lib/getAdjacentFestivals'
 
 import { FestivalDetailContent } from './components/FestivalDetailContent'
+import { FestivalNavigator } from './components/FestivalNavigator'
 
 export async function generateStaticParams() {
   const slugs = await getFestivalSlugs()
@@ -54,6 +56,7 @@ export default async function FestivalDetailPage({
   if (!slug) notFound()
 
   const detail = await getFestivalBySlug(slug)
+  const adjacent = await getAdjacentFestivals(slug)
 
   if (!detail) notFound()
 
@@ -64,6 +67,7 @@ export default async function FestivalDetailPage({
         sectionPath={`/festivales/${slug}`}
       />
       <FestivalDetailContent detail={detail} />
+      <FestivalNavigator prev={adjacent.prev} next={adjacent.next} />
     </>
   )
 }

--- a/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
+++ b/apps/web/src/app/(sections)/festivales/[slug]/page.tsx
@@ -56,7 +56,6 @@ export default async function FestivalDetailPage({
   if (!slug) notFound()
 
   const detail = await getFestivalBySlug(slug)
-  const adjacent = await getAdjacentFestivals(slug)
 
   if (!detail) notFound()
 
@@ -67,7 +66,6 @@ export default async function FestivalDetailPage({
         sectionPath={`/festivales/${slug}`}
       />
       <FestivalDetailContent detail={detail} />
-      <FestivalNavigator prev={adjacent.prev} next={adjacent.next} />
     </>
   )
 }

--- a/apps/web/src/app/(sections)/festivales/adapters/mocks/festivalesData.mock.ts
+++ b/apps/web/src/app/(sections)/festivales/adapters/mocks/festivalesData.mock.ts
@@ -10,6 +10,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'XV',
         edicion_nombre: 'Un Nuevo Germinar',
+        edicion_slug: 'edicion-xv-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xv.webp',
         dias: [
@@ -56,6 +57,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'ilustra-benders',
         edicion: '3',
         edicion_nombre: 'Season 3',
+        edicion_slug: 'edicion-3-2',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/ilustra-benders/afiche-3.webp',
         dias: [
@@ -90,6 +92,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'XIV',
         edicion_nombre: null,
+        edicion_slug: 'edicion-xiv-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xiv.webp',
         dias: [
@@ -126,6 +129,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'ilustra-benders',
         edicion: '2',
         edicion_nombre: 'Season 2',
+        edicion_slug: 'edicion-2-2',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/ilustra-benders/afiche-2.webp',
         dias: [
@@ -160,6 +164,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'XIII',
         edicion_nombre: null,
+        edicion_slug: 'edicion-xiii-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xiii.webp',
         dias: [
@@ -196,6 +201,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'ilustra-benders',
         edicion: '1',
         edicion_nombre: null,
+        edicion_slug: 'edicion-1-2',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/ilustra-benders/afiche-1.webp',
         dias: [
@@ -230,6 +236,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'XII',
         edicion_nombre: null,
+        edicion_slug: 'edicion-xii-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xii.webp',
         dias: [
@@ -265,6 +272,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'XI',
         edicion_nombre: 'Edición Virtual',
+        edicion_slug: 'edicion-xi-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-xi.webp',
         dias: [
@@ -311,6 +319,7 @@ export function getFestivalesMock(): FestivalEdicion[] {
         slug: 'frijol-magico',
         edicion: 'X',
         edicion_nombre: 'Décimo Aniversario',
+        edicion_slug: 'edicion-x-1',
         poster_url:
           'https://cdn.frijolmagico.cl/festivales/frijol-magico/afiche-x.webp',
         dias: [

--- a/apps/web/src/app/(sections)/festivales/adapters/queries/festivalesQuery.test.ts
+++ b/apps/web/src/app/(sections)/festivales/adapters/queries/festivalesQuery.test.ts
@@ -1,0 +1,9 @@
+import { describe, expect, test } from 'bun:test'
+
+import { FESTIVALES_QUERY } from './festivalesQuery'
+
+describe('FESTIVALES_QUERY', () => {
+  test('includes edition slug in evento object', () => {
+    expect(FESTIVALES_QUERY).toContain("'edicion_slug', ee.slug")
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/adapters/queries/festivalesQuery.ts
+++ b/apps/web/src/app/(sections)/festivales/adapters/queries/festivalesQuery.ts
@@ -5,6 +5,7 @@ export const FESTIVALES_QUERY = `SELECT json_object(
         'slug', e.slug,
         'edicion', ee.numero_edicion,
         'edicion_nombre', ee.nombre,
+        'edicion_slug', ee.slug,
         'poster_url', ee.poster_url,
         'dias', COALESCE((
             SELECT json_group_array(

--- a/apps/web/src/app/(sections)/festivales/components/FestivalTimelineCard.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalTimelineCard.tsx
@@ -1,3 +1,6 @@
+import Link from 'next/link'
+import { ArrowRightIcon } from 'lucide-react'
+
 import { cn } from '@/utils/cn'
 import { getDaysDisplay, getLocation } from '../utils/timelineUtils'
 
@@ -45,12 +48,12 @@ export const FestivalTimelineCard = ({
   const disciplineColors = ['bg-secondary', 'bg-primary', 'bg-accent']
 
   return (
-    <div className='relative w-full max-w-160'>
+    <div className='group/card relative w-full max-w-160'>
       <article
         id={festivalId}
         data-festival-id={festivalId}
         className={cn(
-          'group bg-background outline-primary/20 flex cursor-pointer flex-col overflow-hidden rounded-3xl shadow-lg outline transition-all duration-300 outline-dashed hover:scale-[1.01] hover:shadow-xl',
+          'group relative z-10 bg-background outline-primary/20 flex flex-col rounded-3xl shadow-lg outline transition-all duration-300 outline-dashed group-hover/card:scale-[1.01] group-hover/card:shadow-xl',
           alignment === 'right' ? 'md:flex-row-reverse' : 'md:flex-row'
         )}
       >
@@ -102,6 +105,19 @@ export const FestivalTimelineCard = ({
           isActive={isActive}
           priority={priority}
         />
+
+        {/* Bottom link button */}
+        <Link
+          href={`/festivales/${festival.evento.edicion_slug}`}
+          className='group/btn absolute -bottom-4 left-1/2 z-20 -translate-x-1/2'
+        >
+          {/* Plain bg effect — same pattern as ArtistCard */}
+          <div className='absolute -z-10 size-full translate-x-1.5 translate-y-1.5 rounded-lg bg-primary transition-transform duration-300 group-hover/btn:translate-x-0 group-hover/btn:translate-y-0' />
+          <span className='relative flex items-center gap-2 rounded-lg border-2 border-primary bg-background px-6 py-2 font-semibold text-primary transition-colors duration-200 group-hover/btn:bg-primary group-hover/btn:text-background'>
+            Ver más
+            <ArrowRightIcon className='size-4 transition-transform duration-200 group-hover/btn:-rotate-45' />
+          </span>
+        </Link>
       </article>
 
       <FestivalTimelineCardBacklight isActive={isActive} />

--- a/apps/web/src/app/(sections)/festivales/components/FestivalTimelineCard.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalTimelineCard.tsx
@@ -50,7 +50,7 @@ export const FestivalTimelineCard = ({
         id={festivalId}
         data-festival-id={festivalId}
         className={cn(
-          'group bg-background outline-primary/20 flex flex-col overflow-hidden rounded-3xl shadow-lg outline transition-all duration-300 outline-dashed hover:shadow-xl',
+          'group bg-background outline-primary/20 flex cursor-pointer flex-col overflow-hidden rounded-3xl shadow-lg outline transition-all duration-300 outline-dashed hover:scale-[1.01] hover:shadow-xl',
           alignment === 'right' ? 'md:flex-row-reverse' : 'md:flex-row'
         )}
       >

--- a/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.test.tsx
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, mock, test } from 'bun:test'
+import type { ReactNode } from 'react'
+import { cleanup, render, screen } from '@testing-library/react'
+
+import { FestivalesTimelineContent } from './FestivalesTimelineContent'
+
+afterEach(cleanup)
+
+mock.module('next/link', () => ({
+  default: ({ href, children, className }: { href: string; children: ReactNode; className?: string }) => (
+    <a href={href} data-testid='card-link' className={className}>
+      {children}
+    </a>
+  )
+}))
+
+const mockFestivales = [
+  {
+    evento: {
+      evento_id: 1,
+      nombre: 'Festival Frijol Mágico',
+      slug: 'frijol-magico',
+      edicion: 'XV',
+      edicion_nombre: 'Un Nuevo Germinar',
+      edicion_slug: 'edicion-xv-1',
+      poster_url: null,
+      dias: [{ fecha: '2025-10-03', hora_inicio: '11:00', hora_fin: '20:00', modalidad: 'presencial' as const, lugar: null }]
+    },
+    resumen: {
+      total_participantes: { exponentes: 1, talleres: 0, musica: 0 },
+      por_disciplina: { ilustracion: 1 }
+    }
+  },
+  {
+    evento: {
+      evento_id: 2,
+      nombre: 'Ilustradores en Benders',
+      slug: 'ilustra-benders',
+      edicion: '3',
+      edicion_nombre: 'Season 3',
+      edicion_slug: 'edicion-3-2',
+      poster_url: null,
+      dias: [{ fecha: '2025-05-10', hora_inicio: '19:00', hora_fin: '23:00', modalidad: 'presencial' as const, lugar: null }]
+    },
+    resumen: {
+      total_participantes: { exponentes: 1, talleres: 0, musica: 0 },
+      por_disciplina: { ilustracion: 1 }
+    }
+  }
+]
+
+describe('FestivalesTimelineContent', () => {
+  test('wraps each card in a link to the edition detail page', () => {
+    render(<FestivalesTimelineContent festivales={mockFestivales} activeId={null} />)
+
+    const links = screen.getAllByTestId('card-link')
+    const uniqueHrefs = [...new Set(links.map((link) => link.getAttribute('href')))]
+
+    expect(uniqueHrefs).toContain('/festivales/edicion-xv-1')
+    expect(uniqueHrefs).toContain('/festivales/edicion-3-2')
+  })
+
+  test('card and link have interactive hover and focus classes', () => {
+    render(<FestivalesTimelineContent festivales={mockFestivales} activeId={null} />)
+
+    const articles = screen.getAllByRole('article')
+    const firstArticle = articles[0]
+    const firstLink = screen.getAllByTestId('card-link')[0]
+
+    expect(firstArticle?.className).toContain('cursor-pointer')
+    expect(firstArticle?.className).toContain('hover:scale-[1.01]')
+    expect(firstArticle?.className).toContain('hover:shadow-xl')
+    expect(firstLink?.className).toContain('focus-visible:ring-2')
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.test.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.test.tsx
@@ -50,26 +50,23 @@ const mockFestivales = [
 ]
 
 describe('FestivalesTimelineContent', () => {
-  test('wraps each card in a link to the edition detail page', () => {
+  test('each card has a "Ver más" link to the edition detail page', () => {
     render(<FestivalesTimelineContent festivales={mockFestivales} activeId={null} />)
 
-    const links = screen.getAllByTestId('card-link')
-    const uniqueHrefs = [...new Set(links.map((link) => link.getAttribute('href')))]
+    const links = screen.getAllByRole('link')
+    const hrefs = links.map((link) => link.getAttribute('href'))
 
-    expect(uniqueHrefs).toContain('/festivales/edicion-xv-1')
-    expect(uniqueHrefs).toContain('/festivales/edicion-3-2')
+    expect(hrefs).toContain('/festivales/edicion-xv-1')
+    expect(hrefs).toContain('/festivales/edicion-3-2')
   })
 
-  test('card and link have interactive hover and focus classes', () => {
+  test('cards have interactive hover classes via named group', () => {
     render(<FestivalesTimelineContent festivales={mockFestivales} activeId={null} />)
 
     const articles = screen.getAllByRole('article')
     const firstArticle = articles[0]
-    const firstLink = screen.getAllByTestId('card-link')[0]
 
-    expect(firstArticle?.className).toContain('cursor-pointer')
-    expect(firstArticle?.className).toContain('hover:scale-[1.01]')
-    expect(firstArticle?.className).toContain('hover:shadow-xl')
-    expect(firstLink?.className).toContain('focus-visible:ring-2')
+    expect(firstArticle?.className).toContain('group-hover/card:scale-[1.01]')
+    expect(firstArticle?.className).toContain('group-hover/card:shadow-xl')
   })
 })

--- a/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.tsx
@@ -1,5 +1,3 @@
-import Link from 'next/link'
-
 import { FestivalTimelineCard } from './FestivalTimelineCard'
 import { TimelineConnector } from './TimelineConnector'
 import { FestivalsSidebarNav } from './FestivalsSidebarNav'
@@ -46,7 +44,7 @@ export const FestivalesTimelineContent = ({
           <div className='relative grid gap-8 lg:grid-cols-[40rem_40rem]'>
             {/* Superior indicator */}
             <div className='flex flex-col items-center'>
-              <div className='bg-secondary/10 text-secondary relative mx-auto flex size-32 flex-col items-center justify-center rounded-full'>
+              <div className='bg-primary/10 text-primary relative mx-auto flex size-32 flex-col items-center justify-center rounded-full'>
                 <span className='font-josefin landing-0 block text-3xl font-black'>
                   2015
                 </span>
@@ -64,7 +62,7 @@ export const FestivalesTimelineContent = ({
                   fill='none'
                   strokeWidth={6}
                   strokeDasharray='20,10'
-                  className='stroke-secondary'
+                  className='stroke-primary'
                   d='M 10 0 L 10 200'
                 />
               </svg>
@@ -95,10 +93,7 @@ export const FestivalesTimelineContent = ({
                   )}
                 >
                   {!isLeft ? (
-                    <Link
-                      href={`/festivales/${festival.evento.edicion_slug}`}
-                      className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
-                    >
+                    <div className='relative w-full max-w-160'>
                       <FestivalTimelineCard
                         festival={festival}
                         alignment='right'
@@ -106,7 +101,7 @@ export const FestivalesTimelineContent = ({
                         isActive={isActive}
                         priority={isFirstCard}
                       />
-                    </Link>
+                    </div>
                   ) : !isLast ? (
                     <TimelineConnector color={connectorColor} toLeft />
                   ) : null}
@@ -120,10 +115,7 @@ export const FestivalesTimelineContent = ({
                   )}
                 >
                   {isLeft ? (
-                    <Link
-                      href={`/festivales/${festival.evento.edicion_slug}`}
-                      className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
-                    >
+                    <div className='relative w-full max-w-160'>
                       <FestivalTimelineCard
                         festival={festival}
                         alignment='left'
@@ -131,7 +123,7 @@ export const FestivalesTimelineContent = ({
                         isActive={isActive}
                         priority={isFirstCard}
                       />
-                    </Link>
+                    </div>
                   ) : !isLast ? (
                     <TimelineConnector color={connectorColor} />
                   ) : null}
@@ -139,17 +131,14 @@ export const FestivalesTimelineContent = ({
 
                 {/* Mobile: Card centrada debajo del circulo */}
                 <div className='flex justify-center pb-12 lg:hidden'>
-                  <Link
-                    href={`/festivales/${festival.evento.edicion_slug}`}
-                    className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
-                  >
+                  <div className='relative w-full max-w-160'>
                     <FestivalTimelineCard
                       festival={festival}
                       festivalId={festivalId}
                       isActive={isActive}
                       priority={isFirstCard}
                     />
-                  </Link>
+                  </div>
                 </div>
               </section>
             )
@@ -167,11 +156,11 @@ export const FestivalesTimelineContent = ({
                   fill='none'
                   strokeWidth={6}
                   strokeDasharray='20,10'
-                  className='stroke-primary'
+                  className='stroke-secondary'
                   d='M 10 0 L 10 200'
                 />
               </svg>
-              <div className='bg-primary/10 text-primary relative mx-auto flex size-32 flex-col items-center justify-center rounded-full'>
+              <div className='bg-secondary/10 text-secondary relative mx-auto flex size-32 flex-col items-center justify-center rounded-full'>
                 <span className='font-josefin landing-0 block text-3xl font-black'>
                   2026
                 </span>

--- a/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.tsx
+++ b/apps/web/src/app/(sections)/festivales/components/FestivalesTimelineContent.tsx
@@ -1,3 +1,5 @@
+import Link from 'next/link'
+
 import { FestivalTimelineCard } from './FestivalTimelineCard'
 import { TimelineConnector } from './TimelineConnector'
 import { FestivalsSidebarNav } from './FestivalsSidebarNav'
@@ -93,13 +95,18 @@ export const FestivalesTimelineContent = ({
                   )}
                 >
                   {!isLeft ? (
-                    <FestivalTimelineCard
-                      festival={festival}
-                      alignment='right'
-                      festivalId={festivalId}
-                      isActive={isActive}
-                      priority={isFirstCard}
-                    />
+                    <Link
+                      href={`/festivales/${festival.evento.edicion_slug}`}
+                      className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
+                    >
+                      <FestivalTimelineCard
+                        festival={festival}
+                        alignment='right'
+                        festivalId={festivalId}
+                        isActive={isActive}
+                        priority={isFirstCard}
+                      />
+                    </Link>
                   ) : !isLast ? (
                     <TimelineConnector color={connectorColor} toLeft />
                   ) : null}
@@ -113,13 +120,18 @@ export const FestivalesTimelineContent = ({
                   )}
                 >
                   {isLeft ? (
-                    <FestivalTimelineCard
-                      festival={festival}
-                      alignment='left'
-                      festivalId={festivalId}
-                      isActive={isActive}
-                      priority={isFirstCard}
-                    />
+                    <Link
+                      href={`/festivales/${festival.evento.edicion_slug}`}
+                      className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
+                    >
+                      <FestivalTimelineCard
+                        festival={festival}
+                        alignment='left'
+                        festivalId={festivalId}
+                        isActive={isActive}
+                        priority={isFirstCard}
+                      />
+                    </Link>
                   ) : !isLast ? (
                     <TimelineConnector color={connectorColor} />
                   ) : null}
@@ -127,12 +139,17 @@ export const FestivalesTimelineContent = ({
 
                 {/* Mobile: Card centrada debajo del circulo */}
                 <div className='flex justify-center pb-12 lg:hidden'>
-                  <FestivalTimelineCard
-                    festival={festival}
-                    festivalId={festivalId}
-                    isActive={isActive}
-                    priority={isFirstCard}
-                  />
+                  <Link
+                    href={`/festivales/${festival.evento.edicion_slug}`}
+                    className='focus-visible:ring-primary relative w-full max-w-160 rounded-3xl outline-none transition-all focus-visible:ring-2 focus-visible:ring-offset-2'
+                  >
+                    <FestivalTimelineCard
+                      festival={festival}
+                      festivalId={festivalId}
+                      isActive={isActive}
+                      priority={isFirstCard}
+                    />
+                  </Link>
                 </div>
               </section>
             )

--- a/apps/web/src/app/(sections)/festivales/types/festival.test.ts
+++ b/apps/web/src/app/(sections)/festivales/types/festival.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from 'bun:test'
+
+import type {
+  FestivalActivity,
+  FestivalDetail,
+  FestivalEvento,
+  FestivalParticipant,
+  RawFestivalDetail
+} from './festival'
+
+describe('Festival types', () => {
+  test('FestivalEvento includes edition slug for detail links', () => {
+    const evento: FestivalEvento = {
+      evento_id: 1,
+      nombre: 'Festival Frijol Mágico',
+      slug: 'frijol-magico',
+      edicion: 'XV',
+      edicion_nombre: 'Edición XV',
+      edicion_slug: 'edicion-15-1',
+      poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+      dias: []
+    }
+
+    expect(evento.edicion_slug).toBe('edicion-15-1')
+  })
+
+  test('FestivalParticipant shape supports catalog and non-catalog participants', () => {
+    const participant: FestivalParticipant = {
+      pseudonimo: 'Artista Ejemplo',
+      disciplina_slug: 'ilustracion',
+      catalogo_slug: 'artista-ejemplo'
+    }
+
+    expect(participant.pseudonimo).toBe('Artista Ejemplo')
+    expect(participant.disciplina_slug).toBe('ilustracion')
+    expect(participant.catalogo_slug).toBe('artista-ejemplo')
+  })
+
+  test('FestivalActivity shape includes scheduling and type fields', () => {
+    const activity: FestivalActivity = {
+      titulo: 'Taller de Acuarela',
+      descripcion: 'Un taller introductorio',
+      duracion_minutos: 90,
+      ubicacion: 'Sala A',
+      hora_inicio: '18:00',
+      tipo: 'taller',
+      fecha: '2025-01-15',
+      participante_pseudonimo: 'Artista Ejemplo'
+    }
+
+    expect(activity.tipo).toBe('taller')
+    expect(activity.fecha).toBe('2025-01-15')
+  })
+
+  test('FestivalDetail shape aggregates edition data', () => {
+    const detail: FestivalDetail = {
+      edition_id: 10,
+      slug: 'edicion-15-1',
+      evento: { nombre: 'Festival Frijol Mágico', slug: 'frijol-magico' },
+      edicion_nombre: 'Edición XV',
+      numero_edicion: 'XV',
+      poster_url: 'https://cdn.frijolmagico.cl/poster.webp',
+      dias: [],
+      participantes: [],
+      actividades: []
+    }
+
+    expect(detail.edition_id).toBe(10)
+    expect(detail.evento.slug).toBe('frijol-magico')
+  })
+
+  test('RawFestivalDetail wraps JSON result string', () => {
+    const raw: RawFestivalDetail = { resultado: '{}' }
+
+    expect(raw.resultado).toBe('{}')
+  })
+})

--- a/apps/web/src/app/(sections)/festivales/types/festival.ts
+++ b/apps/web/src/app/(sections)/festivales/types/festival.ts
@@ -28,6 +28,7 @@ export interface FestivalEvento {
   slug: string
   edicion: string
   edicion_nombre: string | null
+  edicion_slug: string
   poster_url: string | null
   dias: FestivalDia[]
 }
@@ -38,5 +39,41 @@ export interface FestivalEdicion {
 }
 
 export interface RawFestivalEdicion {
+  resultado: string
+}
+
+export interface FestivalParticipant {
+  pseudonimo: string
+  disciplina_slug: string
+  catalogo_slug: string | null
+}
+
+export interface FestivalActivity {
+  titulo: string | null
+  descripcion: string | null
+  duracion_minutos: number | null
+  ubicacion: string | null
+  hora_inicio: string | null
+  tipo: string
+  fecha: string | null
+  participante_pseudonimo: string | null
+}
+
+export interface FestivalDetail {
+  edition_id: number
+  slug: string
+  evento: {
+    nombre: string
+    slug: string
+  }
+  edicion_nombre: string | null
+  numero_edicion: string
+  poster_url: string | null
+  dias: FestivalDia[]
+  participantes: FestivalParticipant[]
+  actividades: FestivalActivity[]
+}
+
+export interface RawFestivalDetail {
   resultado: string
 }

--- a/apps/web/src/hooks/usePosterDominantColor.ts
+++ b/apps/web/src/hooks/usePosterDominantColor.ts
@@ -12,10 +12,7 @@ export function usePosterDominantColor() {
       const parent = ref.current?.parentElement
       if (!parent) return null
 
-      const article = parent.querySelector('article')
-      if (!article) return null
-
-      const img = article.querySelector('img')
+      const img = parent.querySelector('img')
       if (!img || !(img instanceof HTMLImageElement)) return null
 
       if (img.complete) {

--- a/apps/web/src/styles/globals.css
+++ b/apps/web/src/styles/globals.css
@@ -40,3 +40,17 @@
     }
   }
 }
+
+:root {
+  interpolate-size: allow-keywords;
+}
+
+details::details-content {
+  height: 0;
+  overflow: clip;
+  transition: height .3s ease, content-visibility .3s ease allow-discrete;
+}
+
+details[open]::details-content {
+  height: auto;
+}

--- a/apps/web/src/test-utils/mockDatabase.ts
+++ b/apps/web/src/test-utils/mockDatabase.ts
@@ -1,0 +1,9 @@
+import { mock } from 'bun:test'
+
+import { executeQuery } from '@frijolmagico/database/client'
+
+export const executeQueryMock = mock(executeQuery)
+
+mock.module('@frijolmagico/database/client', () => ({
+  executeQuery: executeQueryMock
+}))

--- a/apps/web/test-setup.ts
+++ b/apps/web/test-setup.ts
@@ -11,3 +11,6 @@ for (const key of Object.keys(window)) {
 
 globalThis.window = window as unknown as Window & typeof globalThis
 globalThis.document = window.document as unknown as Document
+globalThis.requestAnimationFrame =
+  globalThis.requestAnimationFrame ??
+  ((callback: FrameRequestCallback) => setTimeout(callback, 16) as unknown as number)


### PR DESCRIPTION
## Summary

- **FestivalNavigator**: prev/next edition navigation on detail page, async self-fetching component with efficient `ROW_NUMBER()` query
- **'Ver más' button**: replaces card-level Link wrappers with a bottom-positioned button using named Tailwind groups for isolated hover behavior
- **Timeline markers**: inverted start/end colors (primary ↔ secondary)
- **Stacking fix**: permanent `z-10` on cards to prevent transition-out glitch
- **Detail page fixes**: typo fix, responsive alignment, ActivityItem min-width

## Changes

| File | Change |
|------|--------|
| `FestivalNavigator.tsx` | New async component, fetches adjacent editions internally |
| `getAdjacentFestivals.ts` | `'use cache'` wrapper with cache tags |
| `adjacentFestivalsRepository.ts` | Repository with chronological `ROW_NUMBER()` query |
| `adjacentFestivalsQuery.ts` | SQL CTE, single bind param, max 2 rows |
| `FestivalTimelineCard.tsx` | 'Ver más' button with plain-bg effect, named groups, z-10 |
| `FestivalesTimelineContent.tsx` | Remove Link wrappers, invert timeline marker colors |
| `FestivalDetailContent.tsx` | Made async, renders FestivalNavigator internally |
| `page.tsx` | Simplified: navigator now inside FestivalDetailContent |
| `ActivityItem.tsx` | Added `min-w-[16rem]` constraint |
| `FestivalDetailPoster.tsx` | Typo fix: `relatie` → `relative`, added `h-auto` |
| `MusicActivityItem.tsx` | Center-align participant name on mobile |
| `ActivityList.tsx` | `flex-1` sections, center headings on mobile |
| Test files | Adapted to async components, new link structure |

## Test Plan

- [x] `bun run type-check` passes
- [x] `bun run test -- --run` — 56/56 pass