### PR TITLE
fix(admin): persist activity details when detail row does not exist

### DIFF
--- a/apps/admin/src/app/(core)/eventos/participaciones/_actions/activities/create-activity-detail.action.ts
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_actions/activities/create-activity-detail.action.ts
@@ -1,0 +1,56 @@
+'use server'
+
+import 'server-only'
+import { updateTag } from 'next/cache'
+import { db } from '@frijolmagico/database/orm'
+import { participations } from '@frijolmagico/database/schema'
+import { requireAuth } from '@/shared/lib/auth/utils'
+import { ActionState } from '@/shared/types/actions'
+import { getParticipationActivitiesCacheTag } from '@frijolmagico/cache-tags'
+import {
+  activityDetailInsertSchema,
+  type ActivityDetailInsertInput
+} from '../../_schemas/activity.schema'
+
+const { activity } = participations
+
+export async function createActivityDetailAction(
+  participationId: number,
+  payload: ActivityDetailInsertInput
+): Promise<ActionState> {
+  try {
+    await requireAuth()
+
+    const parsed = activityDetailInsertSchema.safeParse(payload)
+
+    if (!parsed.success) {
+      return {
+        success: false,
+        errors: parsed.error.issues.map((issue) => ({
+          entityType: 'detalles',
+          message: issue.message
+        }))
+      }
+    }
+
+    await db.insert(activity).values(parsed.data)
+
+    updateTag(getParticipationActivitiesCacheTag(participationId))
+
+    return { success: true }
+  } catch (error) {
+    console.error('[createActivityDetailAction]', error)
+    return {
+      success: false,
+      errors: [
+        {
+          entityType: 'detalles',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Error al guardar los detalles'
+        }
+      ]
+    }
+  }
+}

--- a/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
@@ -30,6 +30,7 @@ import {
 } from '../_constants/participations.constants'
 import { updateParticipationAction } from '../_actions/participations/update-participation.action'
 import { updateActivityAction } from '../_actions/activities/update-activity.action'
+import { createActivityDetailAction } from '../_actions/activities/create-activity-detail.action'
 import { updateActivityDetailAction } from '../_actions/activities/update-activity-detail.action'
 import { executeUpdatePlan } from '../_lib/execute-update-plan'
 import {
@@ -148,41 +149,67 @@ export function UpdateActivityDialog({ edition }: UpdateActivityDialogProps) {
             puntaje: values.puntaje
           })
       },
-      ...(activity.detail
-        ? [
-            {
-              label: 'el detalle de actividad',
-              initial: {
-                id: activity.detail.id,
-                titulo: activity.detail.titulo ?? '',
-                descripcion: activity.detail.descripcion ?? '',
-                duracionMinutos: activity.detail.duracionMinutos ?? null,
-                cupos: activity.detail.cupos ?? null,
-                horaInicio: activity.detail.horaInicio ?? '',
-                ubicacion: activity.detail.ubicacion ?? ''
-              },
-              current: {
-                id: activity.detail.id,
-                titulo: values.detail.titulo ?? '',
-                descripcion: values.detail.descripcion ?? '',
-                duracionMinutos: values.detail.duracionMinutos ?? null,
-                cupos: values.detail.cupos ?? null,
-                horaInicio: values.detail.horaInicio ?? '',
-                ubicacion: values.detail.ubicacion ?? ''
-              },
-              execute: () =>
-                updateActivityDetailAction(activity.participacionId!, {
-                  id: activity.detail!.id,
-                  titulo: values.detail.titulo,
-                  descripcion: values.detail.descripcion,
-                  duracionMinutos: values.detail.duracionMinutos,
-                  cupos: values.detail.cupos,
-                  horaInicio: values.detail.horaInicio,
-                  ubicacion: values.detail.ubicacion
-                })
+      {
+        label: 'el detalle de actividad',
+        initial: activity.detail
+          ? {
+              id: activity.detail.id,
+              titulo: activity.detail.titulo ?? '',
+              descripcion: activity.detail.descripcion ?? '',
+              duracionMinutos: activity.detail.duracionMinutos ?? null,
+              cupos: activity.detail.cupos ?? null,
+              horaInicio: activity.detail.horaInicio ?? '',
+              ubicacion: activity.detail.ubicacion ?? ''
             }
-          ]
-        : [])
+          : {
+              participacionActividadId: activity.id,
+              titulo: '',
+              descripcion: '',
+              duracionMinutos: null,
+              cupos: null,
+              horaInicio: '',
+              ubicacion: ''
+            },
+        current: activity.detail
+          ? {
+              id: activity.detail.id,
+              titulo: values.detail.titulo ?? '',
+              descripcion: values.detail.descripcion ?? '',
+              duracionMinutos: values.detail.duracionMinutos ?? null,
+              cupos: values.detail.cupos ?? null,
+              horaInicio: values.detail.horaInicio ?? '',
+              ubicacion: values.detail.ubicacion ?? ''
+            }
+          : {
+              participacionActividadId: activity.id,
+              titulo: values.detail.titulo ?? '',
+              descripcion: values.detail.descripcion ?? '',
+              duracionMinutos: values.detail.duracionMinutos ?? null,
+              cupos: values.detail.cupos ?? null,
+              horaInicio: values.detail.horaInicio ?? '',
+              ubicacion: values.detail.ubicacion ?? ''
+            },
+        execute: () =>
+          activity.detail
+            ? updateActivityDetailAction(activity.participacionId!, {
+                id: activity.detail.id,
+                titulo: values.detail.titulo,
+                descripcion: values.detail.descripcion,
+                duracionMinutos: values.detail.duracionMinutos,
+                cupos: values.detail.cupos,
+                horaInicio: values.detail.horaInicio,
+                ubicacion: values.detail.ubicacion
+              })
+            : createActivityDetailAction(activity.participacionId!, {
+                participacionActividadId: activity.id,
+                titulo: values.detail.titulo,
+                descripcion: values.detail.descripcion,
+                duracionMinutos: values.detail.duracionMinutos,
+                cupos: values.detail.cupos,
+                horaInicio: values.detail.horaInicio,
+                ubicacion: values.detail.ubicacion
+              })
+      }
     ])
 
     if (!result.success) {

--- a/apps/admin/tests/unit/app/(core)/eventos/participaciones/_actions/create-activity-detail.action.test.ts
+++ b/apps/admin/tests/unit/app/(core)/eventos/participaciones/_actions/create-activity-detail.action.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test'
+
+const updateTag = mock(() => {})
+const requireAuth = mock(async () => ({ user: { id: '1' } }))
+
+type InsertState = {
+  valuesArgs: unknown[]
+}
+
+function createDbMock() {
+  const insertState: InsertState = { valuesArgs: [] }
+
+  return {
+    insertState,
+    db: {
+      insert: () => ({
+        values: (...args: unknown[]) => {
+          insertState.valuesArgs.push(...args)
+          return Promise.resolve()
+        }
+      })
+    }
+  }
+}
+
+let currentDb = createDbMock().db
+
+mock.module('server-only', () => ({}))
+mock.module('next/cache', () => ({ cacheTag: mock(() => {}), updateTag }))
+mock.module('next/cache.js', () => ({ cacheTag: mock(() => {}), updateTag }))
+mock.module('@/shared/lib/auth/utils', () => ({ requireAuth }))
+mock.module('@frijolmagico/database/orm', () => ({
+  db: new Proxy(
+    {},
+    {
+      get: (_, prop) => currentDb[prop as keyof typeof currentDb]
+    }
+  )
+}))
+
+const { createActivityDetailAction } = await import(
+  '@/core/eventos/participaciones/_actions/activities/create-activity-detail.action'
+)
+
+describe('createActivityDetailAction', () => {
+  beforeEach(() => {
+    updateTag.mockClear()
+    requireAuth.mockClear()
+    currentDb = createDbMock().db
+  })
+
+  test('requires authentication before validating or inserting', async () => {
+    const dbMock = createDbMock()
+    currentDb = dbMock.db
+
+    await createActivityDetailAction(1, {
+      participacionActividadId: 10,
+      titulo: 'Taller',
+      descripcion: null,
+      duracionMinutos: null,
+      cupos: null,
+      horaInicio: '',
+      ubicacion: ''
+    })
+
+    expect(requireAuth).toHaveBeenCalledTimes(1)
+  })
+
+  test('rejects invalid payload and does not insert', async () => {
+    const dbMock = createDbMock()
+    currentDb = dbMock.db
+
+    const result = await createActivityDetailAction(1, {
+      participacionActividadId: 'not-a-number',
+      titulo: 'Taller',
+      descripcion: null,
+      duracionMinutos: null,
+      cupos: null,
+      horaInicio: '',
+      ubicacion: ''
+    } as unknown as Parameters<typeof createActivityDetailAction>[1])
+
+    expect(result.success).toBe(false)
+    expect(dbMock.insertState.valuesArgs).toHaveLength(0)
+  })
+
+  test('inserts detail row and invalidates participation activities cache', async () => {
+    const dbMock = createDbMock()
+    currentDb = dbMock.db
+
+    const payload = {
+      participacionActividadId: 10,
+      titulo: 'Taller de cerámica',
+      descripcion: 'Introducción',
+      duracionMinutos: 90,
+      cupos: 15,
+      horaInicio: '10:00',
+      ubicacion: 'Sala A'
+    }
+
+    const result = await createActivityDetailAction(1, payload)
+
+    expect(result.success).toBe(true)
+    expect(dbMock.insertState.valuesArgs).toHaveLength(1)
+    expect(dbMock.insertState.valuesArgs[0]).toEqual(payload)
+    expect(updateTag).toHaveBeenCalledTimes(1)
+  })
+
+  test('strips unknown fields before inserting', async () => {
+    const dbMock = createDbMock()
+    currentDb = dbMock.db
+
+    const result = await createActivityDetailAction(1, {
+      participacionActividadId: 10,
+      titulo: 'Taller',
+      descripcion: null,
+      duracionMinutos: null,
+      cupos: null,
+      horaInicio: '',
+      ubicacion: '',
+      extraField: 'should-be-ignored'
+    } as unknown as Parameters<typeof createActivityDetailAction>[1])
+
+    expect(result.success).toBe(true)
+    expect(dbMock.insertState.valuesArgs[0]).not.toHaveProperty('extraField')
+  })
+
+  test('returns failure when the database insert throws', async () => {
+    currentDb = {
+      insert: () => ({
+        values: () => Promise.reject(new Error('connection lost'))
+      })
+    }
+
+    const result = await createActivityDetailAction(1, {
+      participacionActividadId: 10,
+      titulo: 'Taller',
+      descripcion: null,
+      duracionMinutos: null,
+      cupos: null,
+      horaInicio: '',
+      ubicacion: ''
+    })
+
+    expect(result.success).toBe(false)
+    expect(result.errors?.[0].message).toBe('connection lost')
+  })
+})

--- a/apps/admin/tests/unit/app/(core)/eventos/participaciones/_components/update-activity-dialog.contracts.test.ts
+++ b/apps/admin/tests/unit/app/(core)/eventos/participaciones/_components/update-activity-dialog.contracts.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from 'bun:test'
+import { readFileSync } from 'node:fs'
+
+const DIALOG_PATH =
+  '/home/strocs/dev/FrijolMagico/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx'
+
+describe('update activity dialog detail persistence contracts', () => {
+  test('imports the create detail action alongside the update action', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    expect(source).toContain(
+      "import { createActivityDetailAction } from '../_actions/activities/create-activity-detail.action'"
+    )
+    expect(source).toContain(
+      "import { updateActivityDetailAction } from '../_actions/activities/update-activity-detail.action'"
+    )
+  })
+
+  test('always includes a detail step instead of conditionally spreading it', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    expect(source).not.toContain('...(activity.detail')
+    expect(source).toContain("label: 'el detalle de actividad'")
+    expect(source).toContain('createActivityDetailAction')
+    expect(source).toContain('updateActivityDetailAction')
+  })
+
+  test('branches detail execution on activity.detail presence', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    expect(source).toMatch(/activity\.detail\s*\?\s*updateActivityDetailAction/)
+    expect(source).toMatch(/:\s*createActivityDetailAction/)
+  })
+
+  test('provides default empty detail diff when no detail exists', () => {
+    const source = readFileSync(DIALOG_PATH, 'utf8')
+
+    expect(source).toContain('participacionActividadId: activity.id')
+    expect(source).toContain("titulo: ''")
+    expect(source).toContain("descripcion: ''")
+    expect(source).toContain('duracionMinutos: null')
+    expect(source).toContain('cupos: null')
+    expect(source).toContain("horaInicio: ''")
+    expect(source).toContain("ubicacion: ''")
+  })
+})


### PR DESCRIPTION
## Summary

- Fixes silent data loss when editing activity details without an existing `actividad` row
- Adds `createActivityDetailAction` server action for INSERT into `actividad`
- Modifies `update-activity-dialog.tsx` to always include the detail step in `executeUpdatePlan`, branching between INSERT and UPDATE

## Root Cause

Two-level bug:
1. **Frontend**: The detail update step was conditionally excluded from the execution plan when `activity.detail` was `null`
2. **Backend**: `updateActivityDetailAction` did a pure UPDATE — 0 affected rows silently returned success

## Changes

| File | Change |
|------|--------|
| `create-activity-detail.action.ts` | New server action — INSERT into `actividad` with validation and cache invalidation |
| `update-activity-dialog.tsx` | Always include detail step, branch INSERT vs UPDATE based on `activity.detail` |
| `create-activity-detail.action.test.ts` | 5 unit tests (auth, validation, insert, cache, errors) |
| `update-activity-dialog.contracts.test.ts` | 4 contract tests (import, step inclusion, branch, diff shape) |

## Test Plan

- [x] 9 tests passing (5 unit + 4 contract)
- [x] Admin type-check passes
- [x] Manual testing: null detail → fill form → persist ✅; existing detail → edit → persist ✅

## SDD Artifacts

`openspec/changes/archive/2026-07-04-fix-activity-detail-persistence/`