### PR TITLE
feat(admin): add soft-delete panel to catálogo and fix modal close in participaciones

### DIFF
--- a/apps/admin/src/app/(core)/artistas/catalogo/_actions/restore-catalog.action.ts
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_actions/restore-catalog.action.ts
@@ -1,0 +1,45 @@
+'use server'
+
+import 'server-only'
+
+import { updateTag } from 'next/cache'
+
+import { db } from '@frijolmagico/database/orm'
+import { artist } from '@frijolmagico/database/schema'
+import { and, eq, isNotNull } from 'drizzle-orm'
+import { requireAuth } from '@/shared/lib/auth/utils'
+import { CATALOG_CACHE_TAG } from '@frijolmagico/cache-tags'
+import type { ActionState } from '@/shared/types/actions'
+
+export async function restoreCatalogAction(id: number): Promise<ActionState> {
+  try {
+    await requireAuth()
+
+    await db
+      .update(artist.catalogArtist)
+      .set({ deletedAt: null })
+      .where(
+        and(
+          eq(artist.catalogArtist.id, id),
+          isNotNull(artist.catalogArtist.deletedAt)
+        )
+      )
+
+    updateTag(CATALOG_CACHE_TAG)
+
+    return { success: true }
+  } catch (error) {
+    return {
+      success: false,
+      errors: [
+        {
+          entityType: 'catalogo',
+          message:
+            error instanceof Error
+              ? error.message
+              : 'Error desconocido al restaurar el catálogo'
+        }
+      ]
+    }
+  }
+}

--- a/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-container.tsx
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-container.tsx
@@ -6,6 +6,10 @@ import type {
   CatalogAvailableArtist,
   CatalogListItem
 } from '../_types/catalog-list-item'
+import { DeletedToggle } from '@/shared/components/deleted-toggle-list'
+import { useDeletedToggleList } from '@/shared/components/deleted-toggle-list/use-deleted-toggle-list'
+import { deleteCatalogAction } from '../_actions/delete-catalog.action'
+import { restoreCatalogAction } from '../_actions/restore-catalog.action'
 import { CatalogFilters } from './catalog-filters'
 import { CreateCatalogDialog } from './create-catalog-dialog'
 import { UpdateCatalogDialog } from './update-catalog-dialog'
@@ -16,12 +20,14 @@ import { EmptyState } from '@/shared/components/empty-state'
 
 interface CatalogContainerProps {
   catalog: CatalogListItem[]
+  deletedCatalog: CatalogListItem[]
   availableArtists: CatalogAvailableArtist[]
   pagination: PaginationParams
 }
 
 export function CatalogContainer({
   catalog,
+  deletedCatalog,
   availableArtists,
   pagination
 }: CatalogContainerProps) {
@@ -29,47 +35,112 @@ export function CatalogContainer({
     shallow: false,
     limitUrlUpdates: debounce(300)
   })
+  const showDeleted = filters.mostrar_eliminados ?? false
 
   const handleClearFilters = () => {
     void setFilters({
       page: 1,
       search: '',
       activo: null,
-      destacado: null
+      destacado: null,
+      mostrar_eliminados: false
     })
   }
+
+  const {
+    visibleItems,
+    toggleShowDeleted,
+    handleDelete,
+    handleRestore,
+    deletedCount,
+    isPending
+  } = useDeletedToggleList({
+    activeItems: catalog,
+    deletedItems: deletedCatalog,
+    showDeleted,
+    onShowDeletedChange: (nextShowDeleted: boolean) => {
+      setFilters({
+        page: 1,
+        mostrar_eliminados: nextShowDeleted ? true : null
+      })
+    },
+    getId: (item) => item.id,
+    isDeleted: (item) => item.deletedAt !== null,
+    deleteItem: deleteCatalogAction,
+    restoreItem: restoreCatalogAction,
+    messages: {
+      deleteSuccess:
+        'El artista del catálogo fue eliminado exitosamente',
+      deleteError:
+        'Ocurrió un error al intentar eliminar al artista del catálogo',
+      restoreSuccess: 'Artista del catálogo restaurado correctamente',
+      restoreError:
+        'Ocurrió un error al intentar restaurar al artista del catálogo'
+    }
+  })
+
+  const emptyState = showDeleted ? (
+    <EmptyState
+      title='No hay artistas eliminados en el catálogo'
+      description='Todavía no existen elementos eliminados para restaurar.'
+    />
+  ) : (
+    <EmptyState
+      title='No se encontraron artistas en el catálogo'
+      description='No hay artistas que coincidan con los filtros aplicados. Intenta ajustar los filtros para encontrar artistas.'
+      action={{
+        label: 'Limpiar filtros',
+        onClick: handleClearFilters
+      }}
+    />
+  )
 
   return (
     <div className='grid space-y-4'>
       <div className='flex items-center justify-between'>
-        <CatalogFilters filters={filters} setFilters={setFilters} />
-        <CreateCatalogDialog availableArtists={availableArtists} />
+        <DeletedToggle
+          showDeleted={showDeleted}
+          onToggle={toggleShowDeleted}
+          deletedCount={deletedCount}
+        />
+
+        {!showDeleted ? (
+          <CreateCatalogDialog availableArtists={availableArtists} />
+        ) : null}
       </div>
 
-      <PaginationControls
-        {...pagination}
-        onPageChange={(newPage) => setFilters({ page: newPage })}
-        itemNoun='artistas'
-      />
+      {!showDeleted ? (
+        <>
+          <CatalogFilters filters={filters} setFilters={setFilters} />
 
-      {catalog.length === 0 ? (
-        <EmptyState
-          title='No se encontraron artistas en el catálogo'
-          description='No hay artistas que coincidan con los filtros aplicados. Intenta ajustar los filtros para encontrar artistas.'
-          action={{
-            label: 'Limpiar filtros',
-            onClick: handleClearFilters
-          }}
-        />
+          <PaginationControls
+            {...pagination}
+            onPageChange={(newPage) => setFilters({ page: newPage })}
+            itemNoun='artistas'
+          />
+        </>
+      ) : null}
+
+      {visibleItems.length === 0 ? (
+        emptyState
       ) : (
-        <CatalogTable items={catalog} onClearFilters={handleClearFilters} />
+        <CatalogTable
+          items={visibleItems}
+          showDeleted={showDeleted}
+          onDelete={handleDelete}
+          onRestore={handleRestore}
+          onClearFilters={handleClearFilters}
+          isPending={isPending}
+        />
       )}
 
-      <PaginationControls
-        {...pagination}
-        onPageChange={(newPage) => setFilters({ page: newPage })}
-        itemNoun='artistas'
-      />
+      {!showDeleted ? (
+        <PaginationControls
+          {...pagination}
+          onPageChange={(newPage) => setFilters({ page: newPage })}
+          itemNoun='artistas'
+        />
+      ) : null}
 
       <UpdateCatalogDialog />
     </div>

--- a/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-row.tsx
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-row.tsx
@@ -15,10 +15,18 @@ import { toast } from 'sonner'
 interface CatalogRowProps {
   catalog: CatalogListItem
   sortable?: boolean
-  onDelete: (id: number) => void
+  isDeletedView?: boolean
+  onDelete: () => void
+  onRestore: () => void
+  isPending?: boolean
 }
 
-export function CatalogRow({ catalog, onDelete }: CatalogRowProps) {
+export function CatalogRow({
+  catalog,
+  isDeletedView = false,
+  onDelete,
+  onRestore
+}: CatalogRowProps) {
   const openUpdateCatalogDialog = useCatalogDialog(
     (s) => s.openUpdateCatalogDialog
   )
@@ -28,22 +36,6 @@ export function CatalogRow({ catalog, onDelete }: CatalogRowProps) {
     activo: catalog.activo,
     destacado: catalog.destacado
   })
-
-  // const {
-  //   attributes,
-  //   listeners,
-  //   setNodeRef,
-  //   transform,
-  //   transition,
-  //   isDragging
-  // } = useSortable({ id: catalog.id, disabled: !sortable })
-
-  // const style = {
-  //   transform: CSS.Transform.toString(transform),
-  //   transition,
-  //   opacity: isDragging ? 0.5 : 1,
-  //   zIndex: isDragging ? 50 : 'auto'
-  // }
 
   const handleToggleActivo = (checked: boolean) => {
     startTransition(async () => {
@@ -69,16 +61,10 @@ export function CatalogRow({ catalog, onDelete }: CatalogRowProps) {
     })
   }
 
-  const handleDelete = () => {
-    onDelete(catalog.id)
-  }
-
-  // ref={setNodeRef}
-  // style={style}
   return (
     <TableRow
       className={cn('group relative min-h-18.25 transition-colors', {
-        // 'bg-accent shadow-lg': isDragging
+        'opacity-60': isDeletedView
       })}
     >
       <TableCell className='w-12'>
@@ -105,42 +91,56 @@ export function CatalogRow({ catalog, onDelete }: CatalogRowProps) {
         </div>
       </TableCell>
 
-      <TableCell>
-        <div className='flex items-center gap-2'>
-          <Switch
-            checked={optimisticFields.destacado}
-            onCheckedChange={handleToggleDestacado}
-          />
-          {optimisticFields.destacado && (
-            <IconStar className='fill-warning text-warning h-4 w-4' />
-          )}
-        </div>
-      </TableCell>
+      {isDeletedView ? (
+        <TableCell>
+          <span className='text-muted-foreground text-sm'>Eliminado</span>
+        </TableCell>
+      ) : (
+        <>
+          <TableCell>
+            <div className='flex items-center gap-2'>
+              <Switch
+                checked={optimisticFields.destacado}
+                onCheckedChange={handleToggleDestacado}
+              />
+              {optimisticFields.destacado && (
+                <IconStar className='fill-warning text-warning h-4 w-4' />
+              )}
+            </div>
+          </TableCell>
 
-      <TableCell>
-        <div className='flex items-center gap-2'>
-          <Switch
-            checked={optimisticFields.activo}
-            onCheckedChange={handleToggleActivo}
-          />
-          {optimisticFields.activo ? (
-            <IconCheck className='h-4 w-4 text-green-600 dark:text-green-500' />
-          ) : (
-            <IconX className='text-destructive h-4 w-4' />
-          )}
-        </div>
-      </TableCell>
+          <TableCell>
+            <div className='flex items-center gap-2'>
+              <Switch
+                checked={optimisticFields.activo}
+                onCheckedChange={handleToggleActivo}
+              />
+              {optimisticFields.activo ? (
+                <IconCheck className='h-4 w-4 text-green-600 dark:text-green-500' />
+              ) : (
+                <IconX className='text-destructive h-4 w-4' />
+              )}
+            </div>
+          </TableCell>
+        </>
+      )}
 
       <TableCell>
         <ActionMenuButton
-          actions={[
-            {
-              label: 'Editar',
-              onClick: () => openUpdateCatalogDialog(catalog, catalog.artist)
-            }
-          ]}
-          isDeleted={false}
-          onDelete={handleDelete}
+          actions={
+            isDeletedView
+              ? []
+              : [
+                  {
+                    label: 'Editar',
+                    onClick: () =>
+                      openUpdateCatalogDialog(catalog, catalog.artist)
+                  }
+                ]
+          }
+          isDeleted={isDeletedView}
+          onDelete={onDelete}
+          onRestore={onRestore}
         />
       </TableCell>
     </TableRow>

--- a/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-table-container.tsx
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-table-container.tsx
@@ -4,20 +4,32 @@ import type { CatalogListItem } from '../_types/catalog-list-item'
 import { CatalogTable } from './catalog-table'
 
 interface CatalogTableContainerProps {
-  catalog: CatalogListItem[]
+  items: CatalogListItem[]
+  showDeleted: boolean
+  onDelete: (id: number) => void
+  onRestore: (id: number) => void
   onClearFilters: () => void
+  isPending: boolean
   canReorder?: boolean
 }
 
 export function CatalogTableContainer({
-  catalog,
+  items,
+  showDeleted,
+  onDelete,
+  onRestore,
   onClearFilters,
+  isPending,
   canReorder = true
 }: CatalogTableContainerProps) {
   return (
     <CatalogTable
-      items={catalog}
+      items={items}
+      showDeleted={showDeleted}
+      onDelete={onDelete}
+      onRestore={onRestore}
       onClearFilters={onClearFilters}
+      isPending={isPending}
       canReorder={canReorder}
     />
   )

--- a/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-table.tsx
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_components/catalog-table.tsx
@@ -7,76 +7,54 @@ import {
   TableHeader,
   TableRow
 } from '@/shared/components/ui/table'
-import { EmptyState } from '@/shared/components/empty-state'
 import { CatalogRow } from './catalog-row'
 import type { CatalogListItem } from '../_types/catalog-list-item'
-import { startTransition, useOptimistic } from 'react'
-import { deleteCatalogAction } from '../_actions/delete-catalog.action'
-import { toast } from 'sonner'
 
 interface CatalogTableProps {
   items: CatalogListItem[]
+  showDeleted: boolean
+  onDelete: (id: number) => void
+  onRestore: (id: number) => void
   onClearFilters: () => void
+  isPending: boolean
   canReorder?: boolean
 }
 
 export function CatalogTable({
   items,
-  onClearFilters,
+  showDeleted,
+  onDelete,
+  onRestore,
+  isPending,
   canReorder = true
 }: CatalogTableProps) {
-  const [optimisticItems, setOptimisticItems] = useOptimistic(
-    items,
-    (current, id: number) => current.filter((cat) => cat.id !== id)
-  )
-
-  if (optimisticItems.length === 0) {
-    return (
-      <EmptyState
-        title='No se encontraron artistas'
-        description='No hay artistas que coincidan con los filtros seleccionados.'
-        action={{
-          label: 'Limpiar filtros',
-          onClick: onClearFilters
-        }}
-      />
-    )
-  }
-
-  const handleCatalogItemDelete = (id: number) => {
-    startTransition(async () => {
-      setOptimisticItems(id)
-      try {
-        const result = await deleteCatalogAction(id)
-        if (result.success)
-          toast.success('El artista del catálogo fue eliminado exitosamente')
-      } catch (error) {
-        toast.error(
-          'Ocurrió un error al intentar eliminar al artista del catálogo'
-        )
-        console.error(error)
-      }
-    })
-  }
-
   return (
     <Table>
       <TableHeader>
         <TableRow>
           <TableHead className='w-12'></TableHead>
           <TableHead>Nombre</TableHead>
-          <TableHead className='w-24'>Destacado</TableHead>
-          <TableHead className='w-24'>Activo</TableHead>
+          {!showDeleted ? (
+            <>
+              <TableHead className='w-24'>Destacado</TableHead>
+              <TableHead className='w-24'>Activo</TableHead>
+            </>
+          ) : (
+            <TableHead className='w-48'>Eliminado</TableHead>
+          )}
           <TableHead className='w-[5%]'></TableHead>
         </TableRow>
       </TableHeader>
       <TableBody>
-        {optimisticItems.map((item) => (
+        {items.map((item) => (
           <CatalogRow
             key={item.id}
             catalog={item}
             sortable={canReorder}
-            onDelete={handleCatalogItemDelete}
+            isDeletedView={showDeleted}
+            onDelete={() => onDelete(item.id)}
+            onRestore={() => onRestore(item.id)}
+            isPending={isPending}
           />
         ))}
       </TableBody>

--- a/apps/admin/src/app/(core)/artistas/catalogo/_lib/get-deleted-catalog.ts
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_lib/get-deleted-catalog.ts
@@ -1,0 +1,117 @@
+import 'server-only'
+import { cacheTag } from 'next/cache'
+import { and, asc, eq, inArray, isNotNull } from 'drizzle-orm'
+
+import { db } from '@frijolmagico/database/orm'
+import { artist } from '@frijolmagico/database/schema'
+import { isNotDeleted } from '@frijolmagico/database/filters'
+
+import { getAvatarUrl } from '@/shared/lib/cdn'
+import { parseRRSS } from '@/shared/lib/rrss'
+
+import { ARTIST_CACHE_TAG, CATALOG_CACHE_TAG } from '@frijolmagico/cache-tags'
+import type { ARTIST_STATUS } from '../../_constants'
+import type { Artist } from '../../_schemas/artista.schema'
+import type { CatalogListItem } from '../_types/catalog-list-item'
+
+const { catalogArtist, artistImage, artist: artistTable } = artist
+
+interface DeletedCatalogArtistRow {
+  id: number
+  pseudonimo: string
+  nombre: string | null
+  rut: string | null
+  telefono: string | null
+  correo: string | null
+  ciudad: string | null
+  pais: string | null
+  estadoId: number
+  rrss: string | null
+}
+
+interface DeletedCatalogRow {
+  id: number
+  artistaId: number
+  orden: string
+  destacado: boolean
+  activo: boolean
+  descripcion: string | null
+  deletedAt: string | null
+  artist: DeletedCatalogArtistRow
+}
+
+function mapDeletedCatalogArtist(row: DeletedCatalogArtistRow): Artist {
+  return {
+    ...row,
+    estadoId: row.estadoId as ARTIST_STATUS,
+    rrss: parseRRSS(row.rrss)
+  }
+}
+
+export async function getDeletedCatalog(): Promise<CatalogListItem[]> {
+  'use cache'
+  cacheTag(CATALOG_CACHE_TAG)
+  cacheTag(ARTIST_CACHE_TAG)
+
+  const results: DeletedCatalogRow[] = await db
+    .select({
+      id: catalogArtist.id,
+      artistaId: catalogArtist.artistaId,
+      orden: catalogArtist.orden,
+      destacado: catalogArtist.destacado,
+      activo: catalogArtist.activo,
+      descripcion: catalogArtist.descripcion,
+      deletedAt: catalogArtist.deletedAt,
+      artist: {
+        id: artistTable.id,
+        pseudonimo: artistTable.pseudonimo,
+        nombre: artistTable.nombre,
+        rut: artistTable.rut,
+        telefono: artistTable.telefono,
+        correo: artistTable.correo,
+        ciudad: artistTable.ciudad,
+        pais: artistTable.pais,
+        estadoId: artistTable.estadoId,
+        rrss: artistTable.rrss
+      }
+    })
+    .from(catalogArtist)
+    .innerJoin(artistTable, eq(artistTable.id, catalogArtist.artistaId))
+    .where(isNotNull(catalogArtist.deletedAt))
+    .orderBy(asc(catalogArtist.orden))
+    .limit(100)
+
+  if (results.length === 0) {
+    return []
+  }
+
+  const artistIds = results.map((result) => result.artistaId)
+  const avatars = await db
+    .select({
+      artistaId: artistImage.artistaId,
+      imagenUrl: artistImage.imagenUrl,
+      orden: artistImage.orden
+    })
+    .from(artistImage)
+    .where(
+      and(
+        inArray(artistImage.artistaId, artistIds),
+        eq(artistImage.tipo, 'avatar'),
+        isNotDeleted(artistImage.deletedAt)
+      )
+    )
+    .orderBy(asc(artistImage.orden))
+
+  const avatarMap = new Map<number, string>()
+  for (const avatar of avatars) {
+    if (!avatarMap.has(avatar.artistaId)) {
+      avatarMap.set(avatar.artistaId, avatar.imagenUrl)
+    }
+  }
+
+  return results.map((row) => ({
+    ...row,
+    artist: mapDeletedCatalogArtist(row.artist),
+    avatarUrl: getAvatarUrl(avatarMap.get(row.artistaId) ?? null)
+  }))
+}

--- a/apps/admin/src/app/(core)/artistas/catalogo/_lib/search-params.ts
+++ b/apps/admin/src/app/(core)/artistas/catalogo/_lib/search-params.ts
@@ -5,7 +5,8 @@ export const catalogQueryParams = {
   ...searchParser,
   ...paginationParsers,
   activo: parseAsBoolean,
-  destacado: parseAsBoolean
+  destacado: parseAsBoolean,
+  mostrar_eliminados: parseAsBoolean.withDefault(false)
 }
 
 export const loadCatalogQueryParams = createLoader(catalogQueryParams)

--- a/apps/admin/src/app/(core)/artistas/catalogo/page.tsx
+++ b/apps/admin/src/app/(core)/artistas/catalogo/page.tsx
@@ -1,6 +1,7 @@
 import { SearchParamsProps } from '@/shared/types/search-params'
 import { CatalogContainer } from './_components/catalog-container'
 import { getCatalogData, getArtistsNotInCatalog } from './_lib/get-catalog-data'
+import { getDeletedCatalog } from './_lib/get-deleted-catalog'
 import { loadCatalogQueryParams } from './_lib/search-params'
 
 export default async function CatalogArtistsPage({
@@ -8,10 +9,12 @@ export default async function CatalogArtistsPage({
 }: SearchParamsProps) {
   const params = await loadCatalogQueryParams(searchParams)
 
-  const [{ data, ...pagination }, availableArtists] = await Promise.all([
-    getCatalogData(params),
-    getArtistsNotInCatalog()
-  ])
+  const [{ data, ...pagination }, availableArtists, deletedCatalog] =
+    await Promise.all([
+      getCatalogData(params),
+      getArtistsNotInCatalog(),
+      getDeletedCatalog()
+    ])
 
   return (
     <article className='h-full min-h-max space-y-6'>
@@ -26,6 +29,7 @@ export default async function CatalogArtistsPage({
 
       <CatalogContainer
         catalog={data}
+        deletedCatalog={deletedCatalog}
         availableArtists={availableArtists}
         pagination={pagination}
       />

--- a/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_components/update-activity-dialog.tsx
@@ -192,6 +192,7 @@ export function UpdateActivityDialog({ edition }: UpdateActivityDialogProps) {
 
     toast.success('Cambios guardados')
     methods.reset(values)
+    closeUpdateDialogs()
   }
 
   const detailId = activity.detail?.id

--- a/apps/admin/src/app/(core)/eventos/participaciones/_components/update-exhibition-dialog.tsx
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_components/update-exhibition-dialog.tsx
@@ -141,6 +141,7 @@ export function UpdateExhibitionDialog({ edition }: ExhibitionEditorFormProps) {
 
     toast.success('Cambios guardados')
     methods.reset(values)
+    closeUpdateDialogs()
   }
 
   const isBanned = ARTIST_STATUS.CANCELLED === entity.artist?.statusId

--- a/apps/admin/src/app/(core)/eventos/participaciones/_store/use-participations-store.ts
+++ b/apps/admin/src/app/(core)/eventos/participaciones/_store/use-participations-store.ts
@@ -78,6 +78,8 @@ export const useParticipationsStore = create<ParticipationsStore>((set) => ({
         entity: null,
         exhibition: null
       },
+      isUpdateActivityDialogOpen: false,
+      isUpdateExhibitionDialogOpen: false,
       isRemoveExhibitionDialogOpen: false
     }),
 


### PR DESCRIPTION
## Summary

- Adds a **deleted-items panel** to the Catálogo section (same pattern as Artistas, Agrupaciones, Bandas) — users can now view and restore soft-deleted catalog entries
- Fixes **update modals not closing** after save in the Participaciones section (activity and exhibition dialogs)

## Changes

| File | Change |
|---|---|
| `catalogo/_lib/get-deleted-catalog.ts` | **New** — server query for soft-deleted catalog entries with avatars |
| `catalogo/_actions/restore-catalog.action.ts` | **New** — server action to restore by setting `deletedAt = null` |
| `catalogo/_lib/search-params.ts` | Added `mostrar_eliminados` parser |
| `catalogo/page.tsx` | Loads `deletedCatalog` in parallel and passes to container |
| `catalogo/_components/catalog-container.tsx` | Integrated `DeletedToggle` + `useDeletedToggleList` shared hook |
| `catalogo/_components/catalog-table.tsx` | Supports deleted view — hides switches, shows restore column |
| `catalogo/_components/catalog-row.tsx` | Accepts `isDeletedView`/`onRestore` props; `ActionMenuButton` handles restore |
| `catalogo/_components/catalog-table-container.tsx` | Updated interface to match new `CatalogTable` props |
| `participaciones/_store/use-participations-store.ts` | `closeUpdateDialogs()` now resets `isUpdateActivityDialogOpen` and `isUpdateExhibitionDialogOpen` |
| `participaciones/_components/update-activity-dialog.tsx` | Calls `closeUpdateDialogs()` after successful save |
| `participaciones/_components/update-exhibition-dialog.tsx` | Calls `closeUpdateDialogs()` after successful save |

## Type

- [x] New feature (soft-delete panel)
- [x] Bug fix (modal close)